### PR TITLE
feat: GPU-based particle picking with Reveal-style selection highlighting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "omovi",
-  "version": "0.10.1",
+  "version": "0.11.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "omovi",
-      "version": "0.10.1",
+      "version": "0.11.3",
       "license": "GPLv3",
       "dependencies": {
         "@swc/helpers": "^0.4.14",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omovi",
-  "version": "0.11.3",
+  "version": "0.12.0",
   "description": "Online Molecular Visualizer",
   "author": "andeplane",
   "license": "GPLv3",

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -1,0 +1,16 @@
+import * as THREE from 'three'
+
+/**
+ * Default selection color - matches Reveal's light blue
+ */
+export const DEFAULT_SELECTION_COLOR = new THREE.Color(0.392, 0.392, 1.0)
+
+/**
+ * Outline encoding divisor used in alpha channel encoding/decoding
+ * This value is used to encode the outline index into the alpha channel:
+ * - alpha = (255 - index * OUTLINE_ALPHA_DIVISOR) / 255
+ * And to decode it:
+ * - index = floor((255 - alpha * 255) / OUTLINE_ALPHA_DIVISOR + 0.5)
+ */
+export const OUTLINE_ALPHA_DIVISOR = 16.0
+

--- a/src/core/geometries/particles/shaders/fragment.ts
+++ b/src/core/geometries/particles/shaders/fragment.ts
@@ -135,16 +135,17 @@ void main() {
 	vec3 outgoingLight = reflectedLight.directDiffuse + reflectedLight.indirectDiffuse + reflectedLight.directSpecular + reflectedLight.indirectSpecular + totalEmissiveRadiance;
 
 	#include <envmap_fragment>
-	
-	// Encode outline index in alpha channel (bits 5-8)
-	// Selected particles get outline index 1, unselected get 0
-	float outlineIndex = isSelected > 0.5 ? 1.0 : 0.0;
-	gl_FragColor = vec4(outgoingLight, outlineIndex * 16.0 / 255.0);
-	
+	#include <opaque_fragment>
 	#include <tonemapping_fragment>
 	#include <colorspace_fragment>
 	#include <fog_fragment>
 	#include <premultiplied_alpha_fragment>
 	#include <dithering_fragment>
+	
+	// Encode outline index in alpha channel while keeping alpha mostly opaque
+	// Unselected: alpha = 1.0 (index = 0)
+	// Selected: alpha = ~0.94 (index = 1)
+	float outlineIndex = isSelected > 0.5 ? 1.0 : 0.0;
+	gl_FragColor.a = (255.0 - outlineIndex * 16.0) / 255.0;
 }
 `

--- a/src/core/geometries/particles/shaders/fragment.ts
+++ b/src/core/geometries/particles/shaders/fragment.ts
@@ -145,6 +145,8 @@ void main() {
 	// Encode outline index in alpha channel while keeping alpha mostly opaque
 	// Unselected: alpha = 1.0 (index = 0)
 	// Selected: alpha = ~0.94 (index = 1)
+	// Note: OUTLINE_ALPHA_DIVISOR (16.0) is defined in src/core/constants.ts
+	// and must match the value used in outlineShader.ts for decoding
 	float outlineIndex = isSelected > 0.5 ? 1.0 : 0.0;
 	gl_FragColor.a = (255.0 - outlineIndex * 16.0) / 255.0;
 }

--- a/src/core/geometries/particles/shaders/fragment.ts
+++ b/src/core/geometries/particles/shaders/fragment.ts
@@ -10,6 +10,7 @@ uniform float opacity;
 uniform sampler2D colorTexture;
 uniform sampler2D selectionTexture;
 uniform vec3 selectionColor;
+uniform float outlineAlphaDivisor;
 uniform mat4 projectionMatrix;
 uniform float dataTextureWidth;
 uniform float dataTextureHeight;
@@ -145,9 +146,8 @@ void main() {
 	// Encode outline index in alpha channel while keeping alpha mostly opaque
 	// Unselected: alpha = 1.0 (index = 0)
 	// Selected: alpha = ~0.94 (index = 1)
-	// Note: OUTLINE_ALPHA_DIVISOR (16.0) is defined in src/core/constants.ts
-	// and must match the value used in outlineShader.ts for decoding
+	// Note: outlineAlphaDivisor uniform comes from OUTLINE_ALPHA_DIVISOR in src/core/constants.ts
 	float outlineIndex = isSelected > 0.5 ? 1.0 : 0.0;
-	gl_FragColor.a = (255.0 - outlineIndex * 16.0) / 255.0;
+	gl_FragColor.a = (255.0 - outlineIndex * outlineAlphaDivisor) / 255.0;
 }
 `

--- a/src/core/geometries/particles/shaders/fragment.ts
+++ b/src/core/geometries/particles/shaders/fragment.ts
@@ -8,6 +8,8 @@ uniform float shininess;
 uniform float opacity;
 
 uniform sampler2D colorTexture;
+uniform sampler2D selectionTexture;
+uniform vec3 selectionColor;
 uniform mat4 projectionMatrix;
 uniform float dataTextureWidth;
 uniform float dataTextureHeight;
@@ -49,6 +51,9 @@ void main() {
 	float yCoord = (y + 0.5) / dataTextureHeight; // invert Y axis
 	vec2 textureIndex = vec2(xCoord, yCoord);
 	vec4 particleColor = texture2D(colorTexture, textureIndex);
+	
+	// Check if particle is selected (r channel > 0.5 means selected)
+	float isSelected = texture2D(selectionTexture, textureIndex).r;
 
 	#include <clipping_planes_fragment>
 
@@ -59,7 +64,12 @@ void main() {
 	#include <logdepthbuf_fragment>
 	#include <map_fragment>
 	
-	diffuseColor.rgb *= particleColor.rgb;
+	// Apply selection highlight - blend with selection color
+	vec3 finalColor = particleColor.rgb;
+	if (isSelected > 0.5) {
+		finalColor = mix(particleColor.rgb, selectionColor, 0.5);
+	}
+	diffuseColor.rgb *= finalColor;
 	#include <alphamap_fragment>
 	#include <alphatest_fragment>
 	#include <specularmap_fragment>

--- a/src/core/materials.ts
+++ b/src/core/materials.ts
@@ -1,6 +1,6 @@
 import * as THREE from 'three'
 import DataTexture from 'core/datatexture'
-import { DEFAULT_SELECTION_COLOR } from './constants'
+import { DEFAULT_SELECTION_COLOR, OUTLINE_ALPHA_DIVISOR } from './constants'
 
 export interface Uniforms {
   [name: string]: THREE.IUniform
@@ -109,6 +109,7 @@ const createMaterial = (
     if (selectionTexture) {
       parameters.uniforms.selectionTexture = { value: selectionTexture.getTexture() }
       parameters.uniforms.selectionColor = { value: selectionColor || DEFAULT_SELECTION_COLOR }
+      parameters.uniforms.outlineAlphaDivisor = { value: OUTLINE_ALPHA_DIVISOR }
     }
 
     material.uniforms = parameters.uniforms

--- a/src/core/materials.ts
+++ b/src/core/materials.ts
@@ -107,7 +107,8 @@ const createMaterial = (
     // Add selection texture and color if provided
     if (selectionTexture) {
       parameters.uniforms.selectionTexture = { value: selectionTexture.getTexture() }
-      parameters.uniforms.selectionColor = { value: selectionColor || new THREE.Color(1.0, 0.84, 0.0) } // Default gold
+      // Default to Reveal's light blue: RGB(0.392, 0.392, 1.0)
+      parameters.uniforms.selectionColor = { value: selectionColor || new THREE.Color(0.392, 0.392, 1.0) }
     }
 
     material.uniforms = parameters.uniforms

--- a/src/core/materials.ts
+++ b/src/core/materials.ts
@@ -75,7 +75,9 @@ const createMaterial = (
   vertexShader: string,
   fragmentShader: string,
   colorTexture: DataTexture,
-  radiusTexture: DataTexture
+  radiusTexture: DataTexture,
+  selectionTexture?: DataTexture,
+  selectionColor?: THREE.Color
 ) => {
   if (materialMap[type] != null) {
     return materialMap[type]
@@ -101,6 +103,12 @@ const createMaterial = (
     parameters.uniforms.dataTextureHeight = { value: colorTexture.height }
     parameters.uniforms[colorTexture.name] = { value: rawColorTexture }
     parameters.uniforms[radiusTexture.name] = { value: rawRadiusTexture }
+    
+    // Add selection texture and color if provided
+    if (selectionTexture) {
+      parameters.uniforms.selectionTexture = { value: selectionTexture.getTexture() }
+      parameters.uniforms.selectionColor = { value: selectionColor || new THREE.Color(1.0, 0.84, 0.0) } // Default gold
+    }
 
     material.uniforms = parameters.uniforms
 

--- a/src/core/materials.ts
+++ b/src/core/materials.ts
@@ -1,5 +1,6 @@
 import * as THREE from 'three'
 import DataTexture from 'core/datatexture'
+import { DEFAULT_SELECTION_COLOR } from './constants'
 
 export interface Uniforms {
   [name: string]: THREE.IUniform
@@ -107,8 +108,7 @@ const createMaterial = (
     // Add selection texture and color if provided
     if (selectionTexture) {
       parameters.uniforms.selectionTexture = { value: selectionTexture.getTexture() }
-      // Default to Reveal's light blue: RGB(0.392, 0.392, 1.0)
-      parameters.uniforms.selectionColor = { value: selectionColor || new THREE.Color(0.392, 0.392, 1.0) }
+      parameters.uniforms.selectionColor = { value: selectionColor || DEFAULT_SELECTION_COLOR }
     }
 
     material.uniforms = parameters.uniforms

--- a/src/core/picking/PickingHandler.ts
+++ b/src/core/picking/PickingHandler.ts
@@ -185,11 +185,8 @@ export class PickingHandler {
     const b = this.pixelBuffer[2]
     const a = this.pixelBuffer[3]
 
-    console.log('[PickingHandler] Pixel color:', { r, g, b, a })
-
     // Check if we hit the background (white = 255,255,255)
     if (r === 255 && g === 255 && b === 255) {
-      console.log('[PickingHandler] Hit background (white)')
       return undefined
     }
 

--- a/src/core/picking/PickingHandler.ts
+++ b/src/core/picking/PickingHandler.ts
@@ -1,0 +1,146 @@
+import * as THREE from 'three'
+import { pickingVertexShader, pickingFragmentShader } from './shaders'
+import DataTexture from '../datatexture'
+
+export interface PickResult {
+  particleIndex: number
+  position: THREE.Vector3
+}
+
+export class PickingHandler {
+  private renderer: THREE.WebGLRenderer
+  private pickingTarget: THREE.WebGLRenderTarget
+  private pixelBuffer: Uint8Array
+  private pickingMaterial: THREE.ShaderMaterial
+  private radiusTexture: DataTexture
+
+  constructor(renderer: THREE.WebGLRenderer, radiusTexture: DataTexture) {
+    this.renderer = renderer
+    this.radiusTexture = radiusTexture
+
+    // Create 1x1 render target for picking
+    this.pickingTarget = new THREE.WebGLRenderTarget(1, 1, {
+      minFilter: THREE.NearestFilter,
+      magFilter: THREE.NearestFilter,
+      format: THREE.RGBAFormat,
+      type: THREE.UnsignedByteType
+    })
+
+    this.pixelBuffer = new Uint8Array(4)
+
+    // Create picking material
+    this.pickingMaterial = new THREE.ShaderMaterial({
+      uniforms: {
+        dataTextureWidth: { value: radiusTexture.width },
+        dataTextureHeight: { value: radiusTexture.height },
+        radiusTexture: { value: radiusTexture.getTexture() },
+        inverseModelMatrix: { value: new THREE.Matrix4() }
+      },
+      vertexShader: pickingVertexShader,
+      fragmentShader: pickingFragmentShader,
+      side: THREE.DoubleSide
+    })
+  }
+
+  dispose(): void {
+    this.pickingTarget.dispose()
+    this.pickingMaterial.dispose()
+  }
+
+  /**
+   * Pick a particle at the given screen coordinates
+   * @param x Screen x coordinate (0 to width)
+   * @param y Screen y coordinate (0 to height)
+   * @param camera The camera to use for picking
+   * @param scene The scene to pick from
+   * @param particleMeshes Array of instanced meshes containing particles
+   * @returns PickResult if a particle was hit, undefined otherwise
+   */
+  pick(
+    x: number,
+    y: number,
+    camera: THREE.PerspectiveCamera | THREE.OrthographicCamera,
+    scene: THREE.Scene,
+    particleMeshes: THREE.InstancedMesh[]
+  ): PickResult | undefined {
+    if (particleMeshes.length === 0) {
+      return undefined
+    }
+
+    const { width, height } = this.renderer.getSize(new THREE.Vector2())
+
+    // Create pick camera with view offset to render just the clicked pixel
+    const pickCamera = camera.clone() as THREE.PerspectiveCamera
+    pickCamera.setViewOffset(width, height, x, height - y - 1, 1, 1)
+
+    // Store original materials
+    const originalMaterials = new Map<THREE.InstancedMesh, THREE.Material | THREE.Material[]>()
+
+    // Swap to picking material
+    for (const mesh of particleMeshes) {
+      originalMaterials.set(mesh, mesh.material)
+      
+      // Update picking material uniforms from the original material
+      const originalMaterial = mesh.material as THREE.ShaderMaterial
+      if (originalMaterial.uniforms) {
+        this.pickingMaterial.uniforms.inverseModelMatrix.value.copy(
+          originalMaterial.uniforms.inverseModelMatrix?.value || new THREE.Matrix4()
+        )
+      }
+      
+      mesh.material = this.pickingMaterial
+    }
+
+    // Render to picking target
+    const originalRenderTarget = this.renderer.getRenderTarget()
+    const originalClearColor = this.renderer.getClearColor(new THREE.Color())
+    const originalClearAlpha = this.renderer.getClearAlpha()
+
+    this.renderer.setRenderTarget(this.pickingTarget)
+    this.renderer.setClearColor(0x000000, 0) // Clear with transparent black
+    this.renderer.clear()
+    this.renderer.render(scene, pickCamera)
+
+    // Read the pixel
+    this.renderer.readRenderTargetPixels(
+      this.pickingTarget,
+      0,
+      0,
+      1,
+      1,
+      this.pixelBuffer
+    )
+
+    // Restore original state
+    this.renderer.setRenderTarget(originalRenderTarget)
+    this.renderer.setClearColor(originalClearColor, originalClearAlpha)
+
+    // Restore original materials
+    for (const [mesh, material] of originalMaterials) {
+      mesh.material = material
+    }
+
+    // Decode the particle index from RGB
+    // Check if we hit anything (alpha > 0 means we hit a particle)
+    if (this.pixelBuffer[3] === 0) {
+      return undefined
+    }
+
+    const r = this.pixelBuffer[0]
+    const g = this.pixelBuffer[1]
+    const b = this.pixelBuffer[2]
+
+    const particleIndex = r * 65536 + g * 256 + b
+
+    // Get position from particles (we need to find which mesh contains this particle)
+    // For now, return a zero position - the caller can look up the actual position
+    // from the particle data using the index
+    const position = new THREE.Vector3()
+
+    return {
+      particleIndex,
+      position
+    }
+  }
+}
+

--- a/src/core/picking/index.ts
+++ b/src/core/picking/index.ts
@@ -1,0 +1,4 @@
+export { PickingHandler } from './PickingHandler'
+export type { PickResult } from './PickingHandler'
+export { pickingVertexShader, pickingFragmentShader } from './shaders'
+

--- a/src/core/picking/shaders/index.ts
+++ b/src/core/picking/shaders/index.ts
@@ -1,0 +1,3 @@
+export { default as pickingVertexShader } from './pickingVertex'
+export { default as pickingFragmentShader } from './pickingFragment'
+

--- a/src/core/picking/shaders/pickingFragment.ts
+++ b/src/core/picking/shaders/pickingFragment.ts
@@ -1,0 +1,38 @@
+export default /* glsl */ `
+precision highp float;
+
+uniform mat4 projectionMatrix;
+
+varying vec3 vSurfacePoint;
+varying vec3 vCenter;
+varying float vRadius;
+varying float vParticleIndex;
+
+void main() {
+  vec3 rayTarget = vSurfacePoint;
+  vec3 rayDirection = normalize(rayTarget); // rayOrigin is (0,0,0) in camera space
+
+  vec3 diff = rayTarget - vCenter.xyz;
+  vec3 E = diff;
+  vec3 D = rayDirection;
+
+  float a = dot(D, D);
+  float b = dot(E, D);
+  float c = dot(E, E) - vRadius * vRadius;
+
+  // discriminant of sphere equation (factor 2 removed from b above)
+  float d = b * b - a * c;
+  if (d < 0.0)
+    discard;
+
+  // Encode particle index as RGB color (supports up to ~16M particles)
+  // index = r * 65536 + g * 256 + b
+  float index = vParticleIndex;
+  float r = floor(index / 65536.0);
+  float g = floor(mod(index, 65536.0) / 256.0);
+  float b_val = mod(index, 256.0);
+  
+  gl_FragColor = vec4(r / 255.0, g / 255.0, b_val / 255.0, 1.0);
+}
+`
+

--- a/src/core/picking/shaders/pickingVertex.ts
+++ b/src/core/picking/shaders/pickingVertex.ts
@@ -11,6 +11,10 @@ varying vec3 vCenter;
 varying float vRadius;
 varying float vParticleIndex;
 
+// NOTE: The following utility functions (unpack, makePerpendicular) are duplicated
+// across multiple shader files for convenience. These could be extracted to a shared
+// GLSL chunk file if the codebase grows, but for now the duplication is acceptable.
+
 float unpack(vec4 rgba) {
   float value = (rgba.r * 255. * 255. + rgba.g * 255. + rgba.b);
   if (rgba.a < 1.0) {

--- a/src/core/picking/shaders/pickingVertex.ts
+++ b/src/core/picking/shaders/pickingVertex.ts
@@ -1,0 +1,69 @@
+export default /* glsl */ `
+uniform float dataTextureWidth;
+uniform float dataTextureHeight;
+uniform sampler2D radiusTexture;
+uniform mat4 inverseModelMatrix;
+attribute vec3 particlePosition;
+attribute float particleIndex;
+
+varying vec3 vSurfacePoint;
+varying vec3 vCenter;
+varying float vRadius;
+varying float vParticleIndex;
+
+float unpack(vec4 rgba) {
+  float value = (rgba.r * 255. * 255. + rgba.g * 255. + rgba.b);
+  if (rgba.a < 1.0) {
+    return -value;
+  }
+  return value;
+}
+
+vec3 makePerpendicular(vec3 v) {
+    if(v.x == 0.0 && v.y == 0.0) {
+        if(v.z == 0.0) {
+            return vec3(0.0, 0.0, 0.0);
+        }
+        return vec3(0.0, 1.0, 0.0);
+    }
+    return vec3(-v.y, v.x, 0.0);
+}
+
+vec3 mul3(mat4 M, vec3 v) {
+  vec4 u = M * vec4(v, 1.0);
+  return u.xyz / u.w;
+}
+
+void main() {
+  float x = mod(particleIndex, dataTextureWidth);
+  float y = floor(particleIndex / dataTextureWidth);
+  float xCoord = (x + 0.5) / dataTextureWidth;
+  float yCoord = (y + 0.5) / dataTextureHeight;
+  vec2 textureIndex = vec2(xCoord, yCoord);
+  float particleRadius = unpack(texture2D(radiusTexture, textureIndex));
+
+  vParticleIndex = particleIndex;
+
+  vec3 transformed = position;
+
+  #ifdef USE_INSTANCING
+  vec3 objectToCameraModelSpace = (inverseModelMatrix * vec4(particlePosition - cameraPosition, 1.0)).xyz;
+  vec3 view = normalize(objectToCameraModelSpace);
+  vec3 right = normalize(makePerpendicular(view));
+  vec3 up = cross(right, view);
+  
+  // Factor 2.0 is because geometry is 0.5x
+  vec3 displacement = 2.0 * particleRadius * (position.x * right + position.y * up);
+  // particlePosition + displacement is the current vertex, also move closer to camera so billboard covers the sphere
+  transformed = particlePosition + displacement - particleRadius * view;
+  
+  vSurfacePoint = mul3(modelViewMatrix, transformed);
+  vCenter = mul3(modelViewMatrix, particlePosition);
+  vRadius = particleRadius;
+  #endif
+
+  vec4 mvPosition = modelViewMatrix * vec4(transformed, 1.0);
+  gl_Position = projectionMatrix * mvPosition;
+}
+`
+

--- a/src/core/post-processing/outlineShader.ts
+++ b/src/core/post-processing/outlineShader.ts
@@ -20,6 +20,8 @@ varying vec2 vUv;
 // Decode outline index from alpha channel
 // Alpha encoding: alpha = (255 - index * 16) / 255
 // So: alpha = 1.0 means index = 0, alpha ≈ 0.94 means index = 1
+// Note: OUTLINE_ALPHA_DIVISOR (16.0) is defined in src/core/constants.ts
+// and must match the value used in fragment.ts for encoding
 int decodeOutlineIndex(float alpha) {
   float rawValue = 255.0 - alpha * 255.0;
   return int(rawValue / 16.0 + 0.5);

--- a/src/core/post-processing/outlineShader.ts
+++ b/src/core/post-processing/outlineShader.ts
@@ -17,9 +17,12 @@ uniform float outlineOffset;
 
 varying vec2 vUv;
 
-// Decode outline index from alpha channel (bits 5-8)
+// Decode outline index from alpha channel
+// Alpha encoding: alpha = (255 - index * 16) / 255
+// So: alpha = 1.0 means index = 0, alpha ≈ 0.94 means index = 1
 int decodeOutlineIndex(float alpha) {
-  return int(floor((alpha * 255.0) + 0.5)) >> 4;
+  float rawValue = 255.0 - alpha * 255.0;
+  return int(rawValue / 16.0 + 0.5);
 }
 
 // Sample outline index at pixel offset
@@ -50,15 +53,15 @@ void main() {
                   (outlineE != outlineIndex) || 
                   (outlineW != outlineIndex);
     
-    // If it's an edge, draw white outline
+    // If it's an edge, draw white outline (opaque)
     if (isEdge) {
       gl_FragColor = vec4(1.0, 1.0, 1.0, 1.0);
       return;
     }
   }
   
-  // Not an edge, keep original color
-  gl_FragColor = vec4(color.rgb, 1.0);
+  // Not an edge - make it transparent so we don't overwrite SSAO render
+  gl_FragColor = vec4(0.0, 0.0, 0.0, 0.0);
 }
 `;
 

--- a/src/core/post-processing/outlineShader.ts
+++ b/src/core/post-processing/outlineShader.ts
@@ -1,0 +1,64 @@
+// Post-processing shader for drawing outlines around selected particles
+// Based on Reveal's outline detection approach
+
+export const outlineVertexShader = /* glsl */ `
+varying vec2 vUv;
+
+void main() {
+  vUv = uv;
+  gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+}
+`;
+
+export const outlineFragmentShader = /* glsl */ `
+uniform sampler2D tDiffuse;
+uniform vec2 resolution;
+uniform float outlineOffset;
+
+varying vec2 vUv;
+
+// Decode outline index from alpha channel (bits 5-8)
+int decodeOutlineIndex(float alpha) {
+  return int(floor((alpha * 255.0) + 0.5)) >> 4;
+}
+
+// Sample outline index at pixel offset
+int sampleOutlineIndex(vec2 uv, vec2 offset) {
+  vec2 sampleUv = uv + offset / resolution;
+  if (sampleUv.x < 0.0 || sampleUv.x > 1.0 || sampleUv.y < 0.0 || sampleUv.y > 1.0) {
+    return 0; // Out of bounds = no outline
+  }
+  float alpha = texture2D(tDiffuse, sampleUv).a;
+  return decodeOutlineIndex(alpha);
+}
+
+void main() {
+  vec4 color = texture2D(tDiffuse, vUv);
+  int outlineIndex = decodeOutlineIndex(color.a);
+  
+  // If this pixel has an outline index, check neighbors for edges
+  if (outlineIndex > 0) {
+    // Sample 4 cardinal neighbors at the specified offset
+    int outlineN = sampleOutlineIndex(vUv, vec2(0.0, outlineOffset));
+    int outlineS = sampleOutlineIndex(vUv, vec2(0.0, -outlineOffset));
+    int outlineE = sampleOutlineIndex(vUv, vec2(outlineOffset, 0.0));
+    int outlineW = sampleOutlineIndex(vUv, vec2(-outlineOffset, 0.0));
+    
+    // Check if any neighbor has a different outline index (or none)
+    bool isEdge = (outlineN != outlineIndex) || 
+                  (outlineS != outlineIndex) || 
+                  (outlineE != outlineIndex) || 
+                  (outlineW != outlineIndex);
+    
+    // If it's an edge, draw white outline
+    if (isEdge) {
+      gl_FragColor = vec4(1.0, 1.0, 1.0, 1.0);
+      return;
+    }
+  }
+  
+  // Not an edge, keep original color
+  gl_FragColor = vec4(color.rgb, 1.0);
+}
+`;
+

--- a/src/core/post-processing/outlineShader.ts
+++ b/src/core/post-processing/outlineShader.ts
@@ -14,17 +14,17 @@ export const outlineFragmentShader = /* glsl */ `
 uniform sampler2D tDiffuse;
 uniform vec2 resolution;
 uniform float outlineOffset;
+uniform float outlineAlphaDivisor;
 
 varying vec2 vUv;
 
 // Decode outline index from alpha channel
-// Alpha encoding: alpha = (255 - index * 16) / 255
+// Alpha encoding: alpha = (255 - index * outlineAlphaDivisor) / 255
 // So: alpha = 1.0 means index = 0, alpha ≈ 0.94 means index = 1
-// Note: OUTLINE_ALPHA_DIVISOR (16.0) is defined in src/core/constants.ts
-// and must match the value used in fragment.ts for encoding
+// Note: outlineAlphaDivisor uniform comes from OUTLINE_ALPHA_DIVISOR in src/core/constants.ts
 int decodeOutlineIndex(float alpha) {
   float rawValue = 255.0 - alpha * 255.0;
-  return int(rawValue / 16.0 + 0.5);
+  return int(rawValue / outlineAlphaDivisor + 0.5);
 }
 
 // Sample outline index at pixel offset

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import Particles from './core/geometries/particles/particles'
 import Bonds from './core/geometries/bonds/bonds'
-import Visualizer from './core/visualizer'
+import Visualizer, { ParticleClickEvent } from './core/visualizer'
 import parseXyz from './parsers/xyzparser'
 import parseLAMMPSBinaryDump from './parsers/lammpsbinarydumpparser'
 import parseLAMMPSData from './parsers/lammpsdataparser'
@@ -22,3 +22,5 @@ export {
   getColor,
   createBondsByDistance
 }
+
+export type { ParticleClickEvent }


### PR DESCRIPTION
## Summary

Implements click-to-select functionality for atoms with GPU-based picking and Reveal-style visual highlighting.

## Features

- **GPU-based picking**: Efficient picking using color-encoded IDs rendered to 1x1 pixel target
- **Click detection**: Single-click selection (not drag) with shift-click for multi-selection
- **Reveal-style highlighting**: 
  - Light blue color override (RGB: 0.392, 0.392, 1.0) - configurable via `setSelectionColor()`
  - White outline via post-processing edge detection
  - Preserves SSAO and all rendering effects
- **Debug mode**: `window.visualizer.debugPickingRender = true` to visualize picking buffer

## Technical Details

- Picking uses custom shaders that encode particle IDs as RGB colors
- Selection state stored in DataTexture for efficient GPU updates
- Outline post-processing detects edges by comparing neighboring pixels
- Outline pass renders on top of SSAO render (preserves all effects)

## API

- `onParticleClick` callback in Visualizer constructor
- `setSelected(atomId, selected)` and `clearSelection()` methods
- `setSelectionColor(color)` for custom selection colors
- `debugPickingRender` flag for debugging

## Testing

Tested with:
- Single atom selection
- Multi-selection with shift-click
- Different atom colors (red, blue, yellow)
- Camera rotation (outline stays consistent)
- SSAO preservation