### PR TITLE
feat: Render bonds in picking pass (non-clickable)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omovi",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "description": "Online Molecular Visualizer",
   "author": "andeplane",
   "license": "GPLv3",

--- a/src/core/picking/PickingHandler.ts
+++ b/src/core/picking/PickingHandler.ts
@@ -1,6 +1,9 @@
 import * as THREE from 'three'
 import { pickingVertexShader, pickingFragmentShader } from './shaders'
-import { bondPickingVertexShader, bondPickingFragmentShader } from './shaders/bondPickingShaders'
+import {
+  bondPickingVertexShader,
+  bondPickingFragmentShader
+} from './shaders/bondPickingShaders'
 import DataTexture from '../datatexture'
 
 export interface PickResult {

--- a/src/core/picking/shaders/bondPickingShaders.ts
+++ b/src/core/picking/shaders/bondPickingShaders.ts
@@ -1,0 +1,43 @@
+// Bond picking shaders - render bonds with a fixed ID (0xFFFFFE) so they're visible but not clickable
+
+export const bondPickingVertexShader = /* glsl */ `
+uniform mat4 inverseModelMatrix;
+attribute vec3 position1;
+attribute vec3 position2;
+attribute float bondRadius;
+
+vec3 mul3(mat4 M, vec3 v) {
+  vec4 u = M * vec4(v, 1.0);
+  return u.xyz / u.w;
+}
+
+void main() {
+  vec3 center = (inverseModelMatrix * vec4(0.5 * (position1 + position2), 1.0)).xyz;
+  float height = length(position2 - position1);
+  vec3 newPosition = position;
+  
+  vec3 objectToCameraModelSpace = (inverseModelMatrix * vec4(cameraPosition - center, 1.0)).xyz;
+  
+  vec3 lDir = normalize(position1 - position2);
+  if (dot(objectToCameraModelSpace, lDir) < 0.0) {
+    lDir *= -1.0;
+  }
+
+  vec3 left = normalize(cross(objectToCameraModelSpace, lDir));
+  vec3 up = normalize(cross(left, lDir));
+
+  vec3 surfacePoint = center + mat3(0.5 * height * lDir, bondRadius * left, bondRadius * up) * newPosition;
+  
+  gl_Position = projectionMatrix * modelViewMatrix * vec4(surfacePoint, 1.0);
+}
+`
+
+export const bondPickingFragmentShader = /* glsl */ `
+void main() {
+  // Output RGB (255, 255, 254) which encodes to 0xFFFFFE (16777214)
+  // This is slightly less than white (0xFFFFFF = background)
+  // When this color is clicked, PickingHandler will return undefined (not clickable)
+  gl_FragColor = vec4(1.0, 1.0, 254.0/255.0, 1.0);
+}
+`
+

--- a/src/core/picking/shaders/bondPickingShaders.ts
+++ b/src/core/picking/shaders/bondPickingShaders.ts
@@ -40,4 +40,3 @@ void main() {
   gl_FragColor = vec4(1.0, 1.0, 254.0/255.0, 1.0);
 }
 `
-

--- a/src/core/picking/shaders/index.ts
+++ b/src/core/picking/shaders/index.ts
@@ -1,2 +1,3 @@
 export { default as pickingVertexShader } from './pickingVertex'
 export { default as pickingFragmentShader } from './pickingFragment'
+export { bondPickingVertexShader, bondPickingFragmentShader } from './bondPickingShaders'

--- a/src/core/picking/shaders/index.ts
+++ b/src/core/picking/shaders/index.ts
@@ -1,3 +1,6 @@
 export { default as pickingVertexShader } from './pickingVertex'
 export { default as pickingFragmentShader } from './pickingFragment'
-export { bondPickingVertexShader, bondPickingFragmentShader } from './bondPickingShaders'
+export {
+  bondPickingVertexShader,
+  bondPickingFragmentShader
+} from './bondPickingShaders'

--- a/src/core/visualizer.ts
+++ b/src/core/visualizer.ts
@@ -376,14 +376,16 @@ export default class Visualizer {
       return
     }
 
-    // Get particle meshes from cached meshes
+    // Get particle and bond meshes from cached meshes in a single pass
     const particleMeshes: THREE.InstancedMesh[] = []
+    const bondMeshes: THREE.InstancedMesh[] = []
     for (const mesh of Object.values(this.cachedMeshes)) {
-      if (
-        mesh instanceof THREE.InstancedMesh &&
-        mesh.material === this.materials['particles']
-      ) {
-        particleMeshes.push(mesh)
+      if (mesh instanceof THREE.InstancedMesh) {
+        if (mesh.material === this.materials['particles']) {
+          particleMeshes.push(mesh)
+        } else if (mesh.material === this.materials['bonds']) {
+          bondMeshes.push(mesh)
+        }
       }
     }
 
@@ -408,15 +410,6 @@ export default class Visualizer {
     const y = (clientY / rect.height) * rendererHeight
 
     // Perform picking
-    const bondMeshes: THREE.InstancedMesh[] = []
-    for (const mesh of Object.values(this.cachedMeshes)) {
-      if (
-        mesh instanceof THREE.InstancedMesh &&
-        mesh.material === this.materials['bonds']
-      ) {
-        bondMeshes.push(mesh)
-      }
-    }
 
     const result = this.pickingHandler.pick(
       x,

--- a/src/core/visualizer.ts
+++ b/src/core/visualizer.ts
@@ -417,7 +417,7 @@ export default class Visualizer {
         bondMeshes.push(mesh)
       }
     }
-    
+
     const result = this.pickingHandler.pick(
       x,
       y,

--- a/src/core/visualizer.ts
+++ b/src/core/visualizer.ts
@@ -408,12 +408,23 @@ export default class Visualizer {
     const y = (clientY / rect.height) * rendererHeight
 
     // Perform picking
+    const bondMeshes: THREE.InstancedMesh[] = []
+    for (const mesh of Object.values(this.cachedMeshes)) {
+      if (
+        mesh instanceof THREE.InstancedMesh &&
+        mesh.material === this.materials['bonds']
+      ) {
+        bondMeshes.push(mesh)
+      }
+    }
+    
     const result = this.pickingHandler.pick(
       x,
       y,
       this.camera,
       this.scene,
       particleMeshes,
+      bondMeshes,
       false // Always do actual picking, debug mode just affects rendering
     )
 
@@ -562,12 +573,19 @@ export default class Visualizer {
       // If debug picking is enabled, render with picking material instead
       if (this.debugPickingRender) {
         const particleMeshes: THREE.InstancedMesh[] = []
+        const bondMeshes: THREE.InstancedMesh[] = []
         for (const mesh of Object.values(this.cachedMeshes)) {
           if (
             mesh instanceof THREE.InstancedMesh &&
             mesh.material === this.materials['particles']
           ) {
             particleMeshes.push(mesh)
+          }
+          if (
+            mesh instanceof THREE.InstancedMesh &&
+            mesh.material === this.materials['bonds']
+          ) {
+            bondMeshes.push(mesh)
           }
         }
         // Trigger a debug render (this will render to screen)
@@ -578,6 +596,7 @@ export default class Visualizer {
             this.camera,
             this.scene,
             particleMeshes,
+            bondMeshes,
             true
           )
         }


### PR DESCRIPTION
## Summary
Makes bonds visible during particle picking renders while keeping them non-clickable.

## Implementation
- **Bond Picking Shaders**: Created specialized shaders that render bonds with a fixed ID (0xFFFFFE = RGB 255,255,254)
- **Non-clickable**: When this color is picked, `PickingHandler` returns `undefined` (bonds act as transparent to clicks)
- **Visual Clarity**: Bonds are now visible in the picking render, making the scene look more complete and helping users see spatial relationships

## Technical Details
- Bond ID: `0xFFFFFE` (16777214) - slightly less than white
- Background ID: `0xFFFFFF` (16777215) - pure white  
- Particle IDs: `0x000000` to `0xFFFFFD` - all valid atom indices
- PickingHandler now accepts optional `bondMeshes` array
- Visualizer passes bond meshes in both normal and debug picking modes

## Benefits
- Bonds are visible during picking (better visual feedback)
- Clicking bonds doesn't interfere with particle selection
- Works seamlessly with existing picking infrastructure