### PR TITLE
chore: bump version to 0.17.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omovi",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Online Molecular Visualizer",
   "author": "andeplane",
   "license": "GPLv3",


### PR DESCRIPTION
Version bump to 0.17.0 after merging the modern lighting system migration.