### PR TITLE
feat: remove Travis CI config and migrate to GitHub Actions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,0 @@
-language: node_js
-node_js:
-  - 20
-  - 18

--- a/package.json
+++ b/package.json
@@ -21,9 +21,7 @@
     "lint:fix": "prettier --write 'src/**/*.{ts,tsx}'",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:ui": "vitest --ui",
-    "predeploy": "npm run build",
-    "deploy": "gh-pages -d dist"
+    "test:ui": "vitest --ui"
   },
   "devDependencies": {
     "@parcel/packager-ts": "^2.8.0",
@@ -34,7 +32,6 @@
     "@vitejs/plugin-react": "^4.3.4",
     "@vitest/ui": "^4.0.14",
     "buffer": "^5.7.1",
-    "gh-pages": "^6.3.0",
     "jsdom": "^27.2.0",
     "parcel": "^2.8.0",
     "prettier": "^3.7.2",


### PR DESCRIPTION
## Summary

This PR completes the migration from Travis CI to GitHub Actions by removing legacy Travis CI configuration and the now-unused `gh-pages` npm package.

## Changes

- ✅ Deleted `.travis.yml` (Travis CI configuration)
- ✅ Removed `gh-pages` package from `devDependencies`
- ✅ Removed `deploy` and `predeploy` scripts from `package.json`

## Background

GitHub Actions workflows for CI and deployment already exist:
- `.github/workflows/ci.yaml` - Runs tests, linting, type checking, and builds on Node 18.x and 20.x
- `.github/workflows/deploy.yaml` - Builds and deploys to GitHub Pages using the modern GitHub Actions deployment method

## Required Manual Step: Update Repository Settings

⚠️ **IMPORTANT**: After merging this PR, you must update the GitHub Pages deployment source in repository settings:

1. Go to: https://github.com/andeplane/omovi/settings/pages
2. Under **Build and deployment** → **Source**
3. Change from **"Deploy from a branch"** to **"GitHub Actions"**

### Why This Is Needed

The current deployment error occurs because:
- The GitHub Actions workflow uses `actions/deploy-pages@v4` (modern approach)
- But the repository is configured for "Deploy from a branch" (legacy approach)
- This mismatch causes: `Invalid deployment branch and no branch protection rules set in the environment`

Once the setting is changed to "GitHub Actions", deployments will work correctly.

## Testing

After merging and updating the repository settings:
1. The deployment workflow should complete successfully on the next push to `main`
2. The site should deploy to https://andeplane.github.io/omovi/

