### PR TITLE
feat: refactor SSAO to use PostProcessingManager

### DIFF
--- a/src/core/PostProcessingManager.ts
+++ b/src/core/PostProcessingManager.ts
@@ -1,0 +1,264 @@
+import * as THREE from 'three'
+import { EffectComposer } from 'three/examples/jsm/postprocessing/EffectComposer.js'
+import { RenderPass } from 'three/examples/jsm/postprocessing/RenderPass.js'
+import { OutputPass } from 'three/examples/jsm/postprocessing/OutputPass.js'
+import { N8AOPass } from 'n8ao'
+
+/**
+ * Settings for Screen Space Ambient Occlusion (SSAO) effect.
+ */
+export interface SSAOSettings {
+  /** Whether SSAO is enabled */
+  enabled: boolean
+  /** AO sampling radius - larger values affect more distant surfaces */
+  radius: number
+  /** AO intensity - higher values create darker shadows */
+  intensity: number
+}
+
+/**
+ * Configuration for all post-processing effects.
+ * Each effect has its own settings object for clean organization.
+ */
+export interface PostProcessingSettings {
+  /** Screen Space Ambient Occlusion settings */
+  ssao: SSAOSettings
+  // Future effects follow same pattern:
+  // bloom: BloomSettings
+  // ssr: SSRSettings
+}
+
+/**
+ * Default post-processing settings.
+ */
+export const DEFAULT_POST_PROCESSING_SETTINGS: PostProcessingSettings = {
+  ssao: {
+    enabled: true,
+    radius: 10.0,
+    intensity: 5.0
+  }
+}
+
+/**
+ * Manages post-processing effects using Three.js EffectComposer.
+ *
+ * This class provides a clean abstraction for adding, configuring, and
+ * rendering post-processing effects. Currently supports N8AO for SSAO.
+ *
+ * @example
+ * ```typescript
+ * const manager = new PostProcessingManager(renderer, scene, camera)
+ * manager.updateSettings({ ssao: { enabled: true, radius: 15, intensity: 3 } })
+ * // In render loop:
+ * manager.render()
+ * ```
+ */
+export class PostProcessingManager {
+  private renderer: THREE.WebGLRenderer
+  private composer: EffectComposer
+  private scene: THREE.Scene
+  private camera: THREE.PerspectiveCamera
+  private beautyRenderTarget: THREE.WebGLRenderTarget | null = null
+
+  // Passes
+  private renderPass: RenderPass
+  private outputPass: OutputPass
+  private n8aoPass: N8AOPass | null = null
+
+  // Current settings
+  private settings: PostProcessingSettings
+
+  constructor(
+    renderer: THREE.WebGLRenderer,
+    scene: THREE.Scene,
+    camera: THREE.PerspectiveCamera,
+    settings: Partial<PostProcessingSettings> = {},
+    beautyRenderTarget?: THREE.WebGLRenderTarget
+  ) {
+    this.renderer = renderer
+    this.scene = scene
+    this.camera = camera
+    this.beautyRenderTarget = beautyRenderTarget || null
+    this.settings = this.mergeSettings(DEFAULT_POST_PROCESSING_SETTINGS, settings)
+
+    // Create effect composer
+    this.composer = new EffectComposer(renderer)
+
+    // Create render pass (always needed)
+    this.renderPass = new RenderPass(scene, camera)
+    this.composer.addPass(this.renderPass)
+
+    // Create output pass (always needed, handles color space)
+    this.outputPass = new OutputPass()
+
+    // Initialize passes based on settings
+    this.initializePasses()
+    this.rebuildPassChain()
+  }
+
+  /**
+   * Deep merge settings with defaults.
+   */
+  private mergeSettings(
+    defaults: PostProcessingSettings,
+    overrides: Partial<PostProcessingSettings>
+  ): PostProcessingSettings {
+    return {
+      ssao: {
+        ...defaults.ssao,
+        ...(overrides.ssao || {})
+      }
+    }
+  }
+
+  /**
+   * Initialize all post-processing passes.
+   */
+  private initializePasses(): void {
+    const size = this.renderer.getSize(new THREE.Vector2())
+    const width = size.x || 1
+    const height = size.y || 1
+
+    // N8AO Pass
+    this.n8aoPass = new N8AOPass(this.scene, this.camera, width, height)
+    
+    // If we have a beauty render target, configure N8AO to use it
+    // This prevents double-rendering of the scene
+    if (this.beautyRenderTarget) {
+      this.n8aoPass.beautyRenderTarget = this.beautyRenderTarget
+      this.n8aoPass.configuration.autoRenderBeauty = false
+    }
+    
+    this.n8aoPass.configuration.aoRadius = this.settings.ssao.radius
+    this.n8aoPass.configuration.intensity = this.settings.ssao.intensity
+    this.n8aoPass.configuration.distanceFalloff = 1.0
+    this.n8aoPass.setQualityMode('Medium')
+  }
+
+  /**
+   * Rebuild the pass chain based on current settings.
+   * Pass order is important for correct rendering.
+   */
+  private rebuildPassChain(): void {
+    // Remove all passes except render pass
+    while (this.composer.passes.length > 0) {
+      this.composer.removePass(this.composer.passes[0])
+    }
+
+    if (!this.beautyRenderTarget) {
+      // Standard mode: render scene ourselves
+      this.composer.addPass(this.renderPass)
+    }
+    // If beautyRenderTarget is provided, scene is already rendered externally
+
+    // Ambient Occlusion (N8AO)
+    if (this.settings.ssao.enabled && this.n8aoPass) {
+      // N8AOPass doesn't extend Pass, so we cast it
+      this.composer.addPass(this.n8aoPass as unknown as RenderPass)
+    }
+
+    if (!this.beautyRenderTarget) {
+      // Standard mode: apply output pass for color space conversion
+      this.composer.addPass(this.outputPass)
+    }
+    // Skip OutputPass when using external render target to match legacy behavior
+  }
+
+  /**
+   * Update settings. Supports partial updates.
+   *
+   * @param settings - Partial settings to update
+   *
+   * @example
+   * ```typescript
+   * manager.updateSettings({ ssao: { intensity: 8 } })
+   * ```
+   */
+  updateSettings(settings: Partial<PostProcessingSettings>): void {
+    const oldSsaoEnabled = this.settings.ssao.enabled
+    this.settings = this.mergeSettings(this.settings, settings)
+
+    // Update N8AO pass settings
+    if (this.n8aoPass) {
+      this.n8aoPass.configuration.aoRadius = this.settings.ssao.radius
+      this.n8aoPass.configuration.intensity = this.settings.ssao.intensity
+    }
+
+    // Rebuild chain if SSAO enabled state changed
+    if (oldSsaoEnabled !== this.settings.ssao.enabled) {
+      this.rebuildPassChain()
+    }
+  }
+
+  /**
+   * Enable or disable SSAO.
+   *
+   * @param enabled - Whether to enable SSAO
+   */
+  setSSAOEnabled(enabled: boolean): void {
+    this.updateSettings({ ssao: { ...this.settings.ssao, enabled } })
+  }
+
+  /**
+   * Update the size of all passes.
+   *
+   * @param width - New width in pixels
+   * @param height - New height in pixels
+   */
+  setSize(width: number, height: number): void {
+    this.composer.setSize(width, height)
+
+    if (this.n8aoPass) {
+      this.n8aoPass.setSize(width, height)
+    }
+  }
+
+  /**
+   * Update the camera reference for all passes.
+   *
+   * @param camera - New camera
+   */
+  setCamera(camera: THREE.PerspectiveCamera): void {
+    this.camera = camera
+    this.renderPass.camera = camera
+
+    if (this.n8aoPass) {
+      this.n8aoPass.camera = camera
+    }
+  }
+
+  /**
+   * Render the scene with all enabled post-processing effects.
+   */
+  render(): void {
+    this.composer.render()
+  }
+
+  /**
+   * Check if any post-processing effects are enabled.
+   *
+   * @returns True if at least one effect is enabled
+   */
+  hasActiveEffects(): boolean {
+    return this.settings.ssao.enabled
+  }
+
+  /**
+   * Get current settings.
+   *
+   * @returns Copy of current settings
+   */
+  getSettings(): PostProcessingSettings {
+    return {
+      ssao: { ...this.settings.ssao }
+    }
+  }
+
+  /**
+   * Dispose of all resources.
+   */
+  dispose(): void {
+    this.n8aoPass?.dispose()
+    this.composer.dispose()
+  }
+}

--- a/src/core/PostProcessingManager.ts
+++ b/src/core/PostProcessingManager.ts
@@ -97,7 +97,7 @@ export class PostProcessingManager {
   }
 
   /**
-   * Deep merge settings with defaults.
+   * Merges settings with defaults.
    */
   private mergeSettings(
     defaults: PostProcessingSettings,

--- a/src/core/PostProcessingManager.ts
+++ b/src/core/PostProcessingManager.ts
@@ -255,6 +255,16 @@ export class PostProcessingManager {
   }
 
   /**
+   * Get the output texture from the composer.
+   * This contains the result of the post-processing pipeline.
+   *
+   * @returns The final texture after all post-processing effects
+   */
+  getOutputTexture(): THREE.Texture {
+    return this.composer.readBuffer.texture
+  }
+
+  /**
    * Dispose of all resources.
    */
   dispose(): void {

--- a/src/core/renderer.ts
+++ b/src/core/renderer.ts
@@ -212,8 +212,8 @@ export default class OMOVIRenderer {
   ) {
     this.onBeforeModelRender()
 
-    // Use PostProcessingManager if available and SSAO is enabled
-    if (this.postProcessingManager && this.renderSsao) {
+    // Use PostProcessingManager if available and has active effects
+    if (this.postProcessingManager && this.postProcessingManager.hasActiveEffects()) {
       // Update camera in case it changed
       if (camera instanceof THREE.PerspectiveCamera) {
         this.postProcessingManager.setCamera(camera)
@@ -227,10 +227,13 @@ export default class OMOVIRenderer {
       
       // Then apply post-processing
       if (target) {
-        // For screenshots, render post-processing, then copy to target
+        // For screenshots, render post-processing, then copy result to target
         this.postProcessingManager.render()
+        const originalTexture = this.rttUniforms.tBase.value
+        this.rttUniforms.tBase.value = this.postProcessingManager.getOutputTexture()
         this.renderer.setRenderTarget(target)
         this.renderer.render(this.rttScene, quadCamera)
+        this.rttUniforms.tBase.value = originalTexture
       } else {
         // Render post-processing directly to screen
         this.postProcessingManager.render()

--- a/src/core/visualizer.ts
+++ b/src/core/visualizer.ts
@@ -912,16 +912,6 @@ export default class Visualizer {
   }
 
   /**
-   * Enable or disable SSAO rendering.
-   *
-   * @param enabled - Whether to enable SSAO
-   */
-  public setPostProcessingEnabled = (enabled: boolean): void => {
-    this.renderer.setSSAOEnabled(enabled)
-    this.forceRender = true
-  }
-
-  /**
    * Enable or disable SSAO (ambient occlusion).
    *
    * @param enabled - Whether to enable SSAO

--- a/src/core/visualizer.ts
+++ b/src/core/visualizer.ts
@@ -11,6 +11,7 @@ import Particles from './geometries/particles/particles'
 import Bonds from './geometries/bonds/bonds'
 import { Color } from './types'
 import OMOVIRenderer from './renderer'
+import { PostProcessingSettings } from './PostProcessingManager'
 import { VRButton } from '../utils/VRButton'
 import { PickingHandler, PickResult } from './picking'
 import {
@@ -847,5 +848,93 @@ export default class Visualizer {
       particleMaterial.uniforms.selectionColor.value.copy(color)
     }
     this.forceRender = true
+  }
+
+  // ============================================
+  // Post-Processing Methods
+  // ============================================
+
+  /**
+   * Initialize the post-processing pipeline.
+   * This sets up EffectComposer with configurable effects.
+   *
+   * @param settings - Optional initial settings for post-processing effects
+   *
+   * @example
+   * ```typescript
+   * visualizer.initPostProcessing({
+   *   ssao: { enabled: true, radius: 15, intensity: 3 }
+   * })
+   * ```
+   */
+  public initPostProcessing = (
+    settings?: Partial<PostProcessingSettings>
+  ): void => {
+    this.renderer.initPostProcessing(this.scene, this.camera, settings)
+    this.forceRender = true
+  }
+
+  /**
+   * Update post-processing settings.
+   *
+   * @param settings - Partial settings to update
+   *
+   * @example
+   * ```typescript
+   * visualizer.updatePostProcessingSettings({
+   *   ssao: { intensity: 8 }
+   * })
+   * ```
+   */
+  public updatePostProcessingSettings = (
+    settings: Partial<PostProcessingSettings>
+  ): void => {
+    this.renderer.updatePostProcessingSettings(settings)
+    this.forceRender = true
+  }
+
+  /**
+   * Get current post-processing settings.
+   *
+   * @returns Current post-processing settings
+   */
+  public getPostProcessingSettings = (): PostProcessingSettings => {
+    return this.renderer.getPostProcessingSettings()
+  }
+
+  /**
+   * Check if post-processing is enabled.
+   *
+   * @returns True if post-processing pipeline is active
+   */
+  public isPostProcessingEnabled = (): boolean => {
+    return this.renderer.isPostProcessingEnabled()
+  }
+
+  /**
+   * Enable or disable SSAO rendering.
+   *
+   * @param enabled - Whether to enable SSAO
+   */
+  public setPostProcessingEnabled = (enabled: boolean): void => {
+    this.renderer.setSSAOEnabled(enabled)
+    this.forceRender = true
+  }
+
+  /**
+   * Enable or disable SSAO (ambient occlusion).
+   *
+   * @param enabled - Whether to enable SSAO
+   *
+   * @example
+   * ```typescript
+   * visualizer.setSSAO(true)
+   * ```
+   */
+  public setSSAO = (enabled: boolean): void => {
+    const currentSettings = this.getPostProcessingSettings()
+    this.updatePostProcessingSettings({
+      ssao: { ...currentSettings.ssao, enabled }
+    })
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,11 @@ import SimulationData from './core/simulationdata/simulationdata'
 import SimulationDataFrame from './core/simulationdata/simulationdataframe'
 import { createBondsByDistance } from './utils/bondcreators'
 import AtomTypes, { getColor } from './core/atomtypes'
+import {
+  PostProcessingSettings,
+  SSAOSettings,
+  DEFAULT_POST_PROCESSING_SETTINGS
+} from './core/PostProcessingManager'
 
 /**
  * Main visualization class that manages the 3D scene, camera, and rendering.
@@ -142,3 +147,14 @@ export { createBondsByDistance }
  * Event data passed when a particle is clicked.
  */
 export type { ParticleClickEvent }
+
+/**
+ * Post-processing settings interface.
+ * Use with visualizer.initPostProcessing() and visualizer.updatePostProcessingSettings().
+ */
+export type { PostProcessingSettings, SSAOSettings }
+
+/**
+ * Default post-processing settings.
+ */
+export { DEFAULT_POST_PROCESSING_SETTINGS }


### PR DESCRIPTION
## Summary

Refactors SSAO implementation to use a centralized PostProcessingManager class, removing duplicate N8AO initialization and providing a clean foundation for future post-processing effects.

## Changes

- **Create PostProcessingManager class** for centralized post-processing control
- **Remove duplicate N8AO setup** from renderer constructor
- **Configure N8AO to reuse beauty render target** - prevents double-rendering and maintains original lighting behavior
- **Add per-effect settings organization** - uses nested objects (e.g., `ssao: { enabled, radius, intensity }`)
- **Expose post-processing API** through Visualizer class
- **Export PostProcessingSettings types** for external use

## Technical Details

- N8AO now uses `beautyRenderTarget` with `autoRenderBeauty = false` to reuse pre-rendered scene
- Skip RenderPass and OutputPass when using external render target to match legacy behavior
- Maintains exact same default values: radius 10.0, intensity 5.0, distanceFalloff 1.0
- Visual output is identical to previous implementation

## Future Work

This architecture makes it easy to add additional post-processing effects:
- Bloom
- Screen Space Reflections (SSR)
- Anti-aliasing (SMAA)
- Depth of Field (Bokeh)

Each effect would follow the same pattern with its own settings object.