### PR TITLE
chore: fix formatting and bump version to 0.19.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omovi",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "description": "Online Molecular Visualizer",
   "author": "andeplane",
   "license": "GPLv3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omovi",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "Online Molecular Visualizer",
   "author": "andeplane",
   "license": "GPLv3",

--- a/src/core/PostProcessingManager.ts
+++ b/src/core/PostProcessingManager.ts
@@ -79,7 +79,10 @@ export class PostProcessingManager {
     this.scene = scene
     this.camera = camera
     this.beautyRenderTarget = beautyRenderTarget || null
-    this.settings = this.mergeSettings(DEFAULT_POST_PROCESSING_SETTINGS, settings)
+    this.settings = this.mergeSettings(
+      DEFAULT_POST_PROCESSING_SETTINGS,
+      settings
+    )
 
     // Create effect composer
     this.composer = new EffectComposer(renderer)
@@ -121,14 +124,14 @@ export class PostProcessingManager {
 
     // N8AO Pass
     this.n8aoPass = new N8AOPass(this.scene, this.camera, width, height)
-    
+
     // If we have a beauty render target, configure N8AO to use it
     // This prevents double-rendering of the scene
     if (this.beautyRenderTarget) {
       this.n8aoPass.beautyRenderTarget = this.beautyRenderTarget
       this.n8aoPass.configuration.autoRenderBeauty = false
     }
-    
+
     this.n8aoPass.configuration.aoRadius = this.settings.ssao.radius
     this.n8aoPass.configuration.intensity = this.settings.ssao.intensity
     this.n8aoPass.configuration.distanceFalloff = 1.0

--- a/src/core/renderer.ts
+++ b/src/core/renderer.ts
@@ -45,7 +45,6 @@ export default class OMOVIRenderer {
   onBeforeModelRender: () => void
   onBeforeSelectRender: () => void
   onAfterRender: () => void
-  public renderSsao: boolean
   private alpha: boolean
   private renderer: THREE.WebGLRenderer
   private modelTarget: THREE.WebGLRenderTarget
@@ -62,10 +61,9 @@ export default class OMOVIRenderer {
   private postProcessingScene: THREE.Scene | null = null
   private postProcessingCamera: THREE.PerspectiveCamera | null = null
 
-  constructor(options: { alpha: boolean; ssao: boolean }) {
-    const { alpha, ssao } = options
+  constructor(options: { alpha: boolean }) {
+    const { alpha } = options
     this.alpha = alpha
-    this.renderSsao = ssao
     this.renderer = new THREE.WebGLRenderer({ alpha })
     this.renderer.outputColorSpace = THREE.SRGBColorSpace
     this.renderer.localClippingEnabled = true
@@ -279,11 +277,6 @@ export default class OMOVIRenderer {
     this.postProcessingScene = scene
     this.postProcessingCamera = camera
 
-    // Apply initial SSAO enabled state from settings
-    if (settings?.ssao?.enabled !== undefined) {
-      this.renderSsao = settings.ssao.enabled
-    }
-
     // Pass the modelTarget so N8AO can reuse it instead of re-rendering
     this.postProcessingManager = new PostProcessingManager(
       this.renderer,
@@ -308,9 +301,6 @@ export default class OMOVIRenderer {
   updatePostProcessingSettings(
     settings: Partial<PostProcessingSettings>
   ): void {
-    if (settings.ssao?.enabled !== undefined) {
-      this.renderSsao = settings.ssao.enabled
-    }
     this.postProcessingManager?.updateSettings(settings)
   }
 
@@ -340,7 +330,6 @@ export default class OMOVIRenderer {
    * @param enabled - Whether to enable SSAO
    */
   setSSAOEnabled(enabled: boolean): void {
-    this.renderSsao = enabled
     this.postProcessingManager?.updateSettings({
       ssao: { ...this.getPostProcessingSettings().ssao, enabled }
     })

--- a/src/core/renderer.ts
+++ b/src/core/renderer.ts
@@ -56,7 +56,7 @@ export default class OMOVIRenderer {
   private rttUniforms: { [name: string]: THREE.IUniform }
   private antiAliasScene: THREE.Scene
   private antiAliasUniforms: { [name: string]: THREE.IUniform }
-  
+
   // Post-processing manager
   private postProcessingManager: PostProcessingManager | null = null
   private postProcessingScene: THREE.Scene | null = null
@@ -213,24 +213,28 @@ export default class OMOVIRenderer {
     this.onBeforeModelRender()
 
     // Use PostProcessingManager if available and has active effects
-    if (this.postProcessingManager && this.postProcessingManager.hasActiveEffects()) {
+    if (
+      this.postProcessingManager &&
+      this.postProcessingManager.hasActiveEffects()
+    ) {
       // Update camera in case it changed
       if (camera instanceof THREE.PerspectiveCamera) {
         this.postProcessingManager.setCamera(camera)
       }
-      
+
       // ALWAYS render scene to modelTarget first
       // This ensures consistent lighting/material behavior
       this.renderer.setRenderTarget(this.modelTarget)
       this.renderer.render(scene, camera)
       this.onBeforeSelectRender()
-      
+
       // Then apply post-processing
       if (target) {
         // For screenshots, render post-processing, then copy result to target
         this.postProcessingManager.render()
         const originalTexture = this.rttUniforms.tBase.value
-        this.rttUniforms.tBase.value = this.postProcessingManager.getOutputTexture()
+        this.rttUniforms.tBase.value =
+          this.postProcessingManager.getOutputTexture()
         this.renderer.setRenderTarget(target)
         this.renderer.render(this.rttScene, quadCamera)
         this.rttUniforms.tBase.value = originalTexture
@@ -301,7 +305,9 @@ export default class OMOVIRenderer {
    *
    * @param settings - Partial settings to update
    */
-  updatePostProcessingSettings(settings: Partial<PostProcessingSettings>): void {
+  updatePostProcessingSettings(
+    settings: Partial<PostProcessingSettings>
+  ): void {
     if (settings.ssao?.enabled !== undefined) {
       this.renderSsao = settings.ssao.enabled
     }

--- a/src/core/visualizer.ts
+++ b/src/core/visualizer.ts
@@ -163,8 +163,7 @@ export default class Visualizer {
     onParticleClick
   }: VisualizerProps = {}) {
     this.renderer = new OMOVIRenderer({
-      alpha: false,
-      ssao: true
+      alpha: false
     })
     this.idle = false
     this.setRadiusCalled = false


### PR DESCRIPTION
Fixes Prettier formatting issues that were causing CI to fail and bumps version to 0.19.1.

This commit was originally part of the post-processing manager PR but got merged before it was included.