### PR TITLE
feat: add orthographic camera support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "omovi",
-  "version": "0.17.0",
+  "version": "0.19.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "omovi",
-      "version": "0.17.0",
+      "version": "0.19.1",
       "license": "GPLv3",
       "dependencies": {
         "@types/binary-parser": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omovi",
-  "version": "0.19.1",
+  "version": "0.20.0",
   "description": "Online Molecular Visualizer",
   "author": "andeplane",
   "license": "GPLv3",

--- a/src/controls/ComboControls.ts
+++ b/src/controls/ComboControls.ts
@@ -262,7 +262,9 @@ export class ComboControls extends EventDispatcher<CameraUpdateEvent> {
     const currentState = this.getState()
 
     this.camera = camera
-    this.reusableCamera = camera.clone() as PerspectiveCamera | OrthographicCamera
+    this.reusableCamera = camera.clone() as
+      | PerspectiveCamera
+      | OrthographicCamera
 
     // Restore state to the new camera
     this.setState(currentState.position, currentState.target)

--- a/src/controls/ComboControls.ts
+++ b/src/controls/ComboControls.ts
@@ -251,6 +251,23 @@ export class ComboControls extends EventDispatcher<CameraUpdateEvent> {
     this.triggerCameraChangeEvent()
   }
 
+  /**
+   * Set the camera used by the controls.
+   * Useful when switching between perspective and orthographic cameras.
+   *
+   * @param camera - The new camera to control
+   */
+  public setCamera = (camera: PerspectiveCamera | OrthographicCamera) => {
+    // Preserve current state
+    const currentState = this.getState()
+
+    this.camera = camera
+    this.reusableCamera = camera.clone() as PerspectiveCamera | OrthographicCamera
+
+    // Restore state to the new camera
+    this.setState(currentState.position, currentState.target)
+  }
+
   public triggerCameraChangeEvent = () => {
     const { camera, target } = this
     this.dispatchEvent({

--- a/src/controls/ComboControls.ts
+++ b/src/controls/ComboControls.ts
@@ -84,7 +84,7 @@ export class ComboControls extends EventDispatcher<CameraUpdateEvent> {
   public dispose: () => void
   public minZoom: number = 0
   public maxZoom: number = Infinity
-  public orthographicCameraDollyFactor: number = 0.3
+  public orthographicCameraDollyFactor: number = 0.03
 
   private temporarilyDisableDamping: boolean = false
   private camera: PerspectiveCamera | OrthographicCamera
@@ -592,14 +592,19 @@ export class ComboControls extends EventDispatcher<CameraUpdateEvent> {
         ? false
         : undefined
     if (moveForward !== undefined) {
-      this.dolly(
-        0,
-        0,
-        this.getDollyDeltaDistance(
+      let deltaDistance: number
+      if (this.camera instanceof THREE.OrthographicCamera) {
+        // For orthographic, use a fixed small zoom factor similar to scroll wheel
+        deltaDistance = moveForward
+          ? -this.orthographicCameraDollyFactor * speedFactor
+          : this.orthographicCameraDollyFactor * speedFactor
+      } else {
+        deltaDistance = this.getDollyDeltaDistance(
           moveForward,
           keyboardDollySpeed * speedFactor
         )
-      )
+      }
+      this.dolly(0, 0, deltaDistance)
       this.firstPersonMode = true
     }
 
@@ -690,7 +695,10 @@ export class ComboControls extends EventDispatcher<CameraUpdateEvent> {
     deltaDistance: number
   ) => {
     const camera = this.camera as OrthographicCamera
-    camera.zoom *= 1 - deltaDistance
+    // deltaDistance should already be normalized (small value like 0.01-0.1)
+    // Clamp to reasonable range to prevent extreme zoom changes
+    const clampedDelta = ThreeMath.clamp(deltaDistance, -0.1, 0.1)
+    camera.zoom *= 1 - clampedDelta
     camera.zoom = ThreeMath.clamp(camera.zoom, this.minZoom, this.maxZoom)
     camera.updateProjectionMatrix()
   }

--- a/src/core/geometries/bonds/shaders/fragment.ts
+++ b/src/core/geometries/bonds/shaders/fragment.ts
@@ -62,9 +62,20 @@ void main() {
 	mat3 basis = mat3(U.xyz, V.xyz, axis.xyz);
     vec3 surfacePoint = vec3(U.w, V.w, axis.w);
     vec3 rayTarget = surfacePoint;
-	vec3 rayDirection = normalize(rayTarget); // rayOrigin is (0,0,0) in camera space
+	vec3 rayDirection;
+	vec3 rayOrigin;
+	
+	if (isOrthographic) {
+		// Orthographic: parallel rays along -Z axis, origin at fragment position
+		rayDirection = vec3(0.0, 0.0, -1.0);
+		rayOrigin = rayTarget;
+	} else {
+		// Perspective: rays diverge from camera at origin (0,0,0)
+		rayDirection = normalize(rayTarget);
+		rayOrigin = vec3(0.0, 0.0, 0.0);
+	}
 
-	vec3 diff = rayTarget - v_position2.xyz;
+	vec3 diff = rayOrigin - v_position2.xyz;
     vec3 E = diff * basis;
     float L = height;
     vec3 D = rayDirection * basis;
@@ -101,7 +112,7 @@ void main() {
     float dist = dist1;
     float intersectionPointZ = E.z + dist*D.z;
     // Intersection point in camera space
-    vec3 p = rayTarget + dist*rayDirection;
+    vec3 p = rayOrigin + dist*rayDirection;
     bool isInner = false;
 
     if (intersectionPointZ <= 0.0 ||
@@ -112,7 +123,7 @@ void main() {
       isInner = true;
       dist = dist2;
       intersectionPointZ = E.z + dist*D.z;
-      p = rayTarget + dist*rayDirection;
+      p = rayOrigin + dist*rayDirection;
 
       if (intersectionPointZ <= 0.0 ||
         intersectionPointZ >= L

--- a/src/core/geometries/bonds/shaders/vertex.ts
+++ b/src/core/geometries/bonds/shaders/vertex.ts
@@ -71,7 +71,14 @@ void main() {
 	height = length(position2-position1);
     vec3 newPosition = position;
 	
-    vec3 objectToCameraModelSpace = (inverseModelMatrix*vec4(cameraPosition - center, 1.0)).xyz;
+	vec3 objectToCameraModelSpace;
+	if (isOrthographic) {
+		// In orthographic mode, view direction is constant (camera's forward direction)
+		objectToCameraModelSpace = normalize((inverseModelMatrix * vec4(0.0, 0.0, -1.0, 0.0)).xyz);
+	} else {
+		// In perspective mode, view direction points from center to camera
+		objectToCameraModelSpace = (inverseModelMatrix * vec4(cameraPosition - center, 1.0)).xyz;
+	}
 	
     vec3 lDir = normalize(position1-position2);
 	float dirSign = 1.0;

--- a/src/core/geometries/bonds/shaders/vertex.ts
+++ b/src/core/geometries/bonds/shaders/vertex.ts
@@ -73,8 +73,9 @@ void main() {
 	
 	vec3 objectToCameraModelSpace;
 	if (isOrthographic) {
-		// In orthographic mode, view direction is constant (camera's forward direction)
-		objectToCameraModelSpace = normalize((inverseModelMatrix * vec4(0.0, 0.0, -1.0, 0.0)).xyz);
+		// In orthographic mode, direction points toward camera (opposite of camera's look direction)
+		// Extract from modelViewMatrix row 2 (the -forward direction in view matrix)
+		objectToCameraModelSpace = normalize(vec3(modelViewMatrix[0][2], modelViewMatrix[1][2], modelViewMatrix[2][2]));
 	} else {
 		// In perspective mode, view direction points from center to camera
 		objectToCameraModelSpace = (inverseModelMatrix * vec4(cameraPosition - center, 1.0)).xyz;

--- a/src/core/geometries/particles/shaders/fragment.ts
+++ b/src/core/geometries/particles/shaders/fragment.ts
@@ -80,9 +80,20 @@ void main() {
 	#include <normal_fragment_maps>
 
 	vec3 rayTarget = vSurfacePoint;
-	vec3 rayDirection = normalize(rayTarget); // rayOrigin is (0,0,0) in camera space
+	vec3 rayDirection;
+	vec3 rayOrigin;
+	
+	if (isOrthographic) {
+		// Orthographic: parallel rays along -Z axis, origin at fragment position
+		rayDirection = vec3(0.0, 0.0, -1.0);
+		rayOrigin = rayTarget;
+	} else {
+		// Perspective: rays diverge from camera at origin (0,0,0)
+		rayDirection = normalize(rayTarget);
+		rayOrigin = vec3(0.0, 0.0, 0.0);
+	}
 
-	vec3 diff = rayTarget - vCenter.xyz;
+	vec3 diff = rayOrigin - vCenter.xyz;
     vec3 E = diff;
     vec3 D = rayDirection;
 
@@ -108,7 +119,7 @@ void main() {
 
     float dist = dist1;
     float intersectionPointZ = E.z + dist*D.z;
-	vec3 p = rayTarget + dist*rayDirection;
+	vec3 p = rayOrigin + dist*rayDirection;
 
 	// Find normal vector in local space
     normal = normalize(vec3(p - vCenter.xyz));

--- a/src/core/geometries/particles/shaders/vertex.ts
+++ b/src/core/geometries/particles/shaders/vertex.ts
@@ -90,9 +90,9 @@ void main() {
 
 	vec3 view;
 	if (isOrthographic) {
-		// In orthographic mode, view direction is constant (camera's forward direction)
-		// Camera looks down -Z in view space, so forward direction is (0, 0, -1)
-		view = normalize((inverseModelMatrix * vec4(0.0, 0.0, -1.0, 0.0)).xyz);
+		// In orthographic mode, all billboards face the camera's forward direction
+		// Extract from modelViewMatrix: third column of rotation part, negated
+		view = -vec3(modelViewMatrix[0][2], modelViewMatrix[1][2], modelViewMatrix[2][2]);
 	} else {
 		// In perspective mode, view direction points from particle to camera
 		vec3 objectToCameraModelSpace = (inverseModelMatrix * vec4(particlePosition - cameraPosition, 1.0)).xyz;

--- a/src/core/geometries/particles/shaders/vertex.ts
+++ b/src/core/geometries/particles/shaders/vertex.ts
@@ -88,8 +88,16 @@ void main() {
 
     #ifdef USE_INSTANCING
 
-	vec3 objectToCameraModelSpace = (inverseModelMatrix*vec4(particlePosition - cameraPosition, 1.0)).xyz;
-    vec3 view = normalize(objectToCameraModelSpace);
+	vec3 view;
+	if (isOrthographic) {
+		// In orthographic mode, view direction is constant (camera's forward direction)
+		// Camera looks down -Z in view space, so forward direction is (0, 0, -1)
+		view = normalize((inverseModelMatrix * vec4(0.0, 0.0, -1.0, 0.0)).xyz);
+	} else {
+		// In perspective mode, view direction points from particle to camera
+		vec3 objectToCameraModelSpace = (inverseModelMatrix * vec4(particlePosition - cameraPosition, 1.0)).xyz;
+		view = normalize(objectToCameraModelSpace);
+	}
     vec3 right = normalize(makePerpendicular(view));
     vec3 up = cross(right, view);
 	

--- a/src/core/input/InputHandler.ts
+++ b/src/core/input/InputHandler.ts
@@ -22,7 +22,7 @@ export interface ParticleClickEvent {
 export class InputHandler {
   private canvas: HTMLCanvasElement
   private pickingHandler: PickingHandler
-  private camera: THREE.PerspectiveCamera
+  private camera: THREE.PerspectiveCamera | THREE.OrthographicCamera
   private scene: THREE.Scene
   private particlesObjects: Particles[]
   private bondsObjects: Bonds[]
@@ -54,7 +54,7 @@ export class InputHandler {
   constructor(
     canvas: HTMLCanvasElement,
     pickingHandler: PickingHandler,
-    camera: THREE.PerspectiveCamera,
+    camera: THREE.PerspectiveCamera | THREE.OrthographicCamera,
     scene: THREE.Scene,
     particlesObjects: Particles[],
     bondsObjects: Bonds[],
@@ -89,6 +89,15 @@ export class InputHandler {
    */
   setCurrentParticles(particles: Particles): void {
     this.currentParticles = particles
+  }
+
+  /**
+   * Set the camera used for picking calculations.
+   *
+   * @param camera - The new camera to use
+   */
+  setCamera(camera: THREE.PerspectiveCamera | THREE.OrthographicCamera): void {
+    this.camera = camera
   }
 
   /**

--- a/src/core/materials.ts
+++ b/src/core/materials.ts
@@ -87,6 +87,7 @@ const createMaterial = (
   const material = new Material(type, { color: 0xffffff })
   material.uniforms.inverseModelMatrix = { value: new THREE.Matrix4() }
   material.uniforms.inverseNormalMatrix = { value: new THREE.Matrix3() }
+  material.uniforms.isOrthographic = { value: false }
 
   if (fragDepthSupported()) {
     material.extensions.fragDepth = true

--- a/src/core/visualizer.ts
+++ b/src/core/visualizer.ts
@@ -905,7 +905,11 @@ export default class Visualizer {
     settings?: Partial<PostProcessingSettings>
   ): void => {
     // Post-processing (SSAO) requires perspective camera
-    this.renderer.initPostProcessing(this.scene, this.perspectiveCamera, settings)
+    this.renderer.initPostProcessing(
+      this.scene,
+      this.perspectiveCamera,
+      settings
+    )
     this.forceRender = true
   }
 

--- a/src/core/visualizer.ts
+++ b/src/core/visualizer.ts
@@ -55,12 +55,19 @@ const makePerpendicular = (v: THREE.Vector3, t: THREE.Vector3) => {
 }
 
 const adjustCamera = (
-  camera: THREE.PerspectiveCamera,
+  camera: THREE.PerspectiveCamera | THREE.OrthographicCamera,
   width: number,
   height: number
 ) => {
   if (camera instanceof THREE.PerspectiveCamera) {
     camera.aspect = width / height
+  } else if (camera instanceof THREE.OrthographicCamera) {
+    // Maintain aspect ratio for orthographic camera
+    const aspect = width / height
+    const frustumHeight = camera.top - camera.bottom
+    const frustumHalfWidth = (frustumHeight * aspect) / 2
+    camera.left = -frustumHalfWidth
+    camera.right = frustumHalfWidth
   }
   camera.updateProjectionMatrix()
 }
@@ -122,7 +129,10 @@ export default class Visualizer {
   public materials: { [key: string]: Material }
   private cachedMeshes: { [key: string]: THREE.Mesh }
   private setRadiusCalled: boolean
-  private camera: THREE.PerspectiveCamera
+  private perspectiveCamera: THREE.PerspectiveCamera
+  private orthographicCamera: THREE.OrthographicCamera
+  private camera: THREE.PerspectiveCamera | THREE.OrthographicCamera
+  private isOrthographicMode: boolean = false
   private controls: ComboControls
   private clock: THREE.Clock
   private domElement?: HTMLElement
@@ -217,13 +227,31 @@ export default class Visualizer {
       this.colorTexture.setRGBA(index, color.r, color.g, color.b)
     })
 
-    this.camera = new THREE.PerspectiveCamera(
+    // Create perspective camera (default)
+    this.perspectiveCamera = new THREE.PerspectiveCamera(
       DEFAULT_CAMERA_FOV,
       640 / 480,
       DEFAULT_CAMERA_NEAR,
       DEFAULT_CAMERA_FAR
     )
-    this.setupCamera(this.camera)
+    this.setupCamera(this.perspectiveCamera)
+
+    // Create orthographic camera with a reasonable default frustum size
+    // The frustum will be adjusted based on scene content
+    const frustumSize = 20
+    const aspect = 640 / 480
+    this.orthographicCamera = new THREE.OrthographicCamera(
+      (-frustumSize * aspect) / 2,
+      (frustumSize * aspect) / 2,
+      frustumSize / 2,
+      -frustumSize / 2,
+      DEFAULT_CAMERA_NEAR,
+      DEFAULT_CAMERA_FAR
+    )
+    this.setupCamera(this.orthographicCamera)
+
+    // Start with perspective camera
+    this.camera = this.perspectiveCamera
     this.controls = new ComboControls(this.camera, this.canvas)
     this.controls.addEventListener('cameraChange', (event) => {
       const { position, target } = event.camera
@@ -423,13 +451,17 @@ export default class Visualizer {
     canvas.style.maxHeight = '100%'
   }
 
-  setupCamera = (camera: THREE.PerspectiveCamera) => {
+  setupCamera = (
+    camera: THREE.PerspectiveCamera | THREE.OrthographicCamera
+  ) => {
     camera.position.set(10, 10, 10)
     camera.lookAt(new THREE.Vector3(0, 0, 0))
   }
 
-  updateUniforms = (camera: THREE.PerspectiveCamera) => {
-    this.object.matrixWorld.copy(this.object.matrixWorld).invert()
+  updateUniforms = (
+    camera: THREE.PerspectiveCamera | THREE.OrthographicCamera
+  ) => {
+    inverseModelMatrix.copy(this.object.matrixWorld).invert()
     modelViewMatrix
       .copy(camera.matrixWorldInverse)
       .multiply(this.object.matrixWorld)
@@ -442,6 +474,9 @@ export default class Visualizer {
       }
       if (material.uniforms.inverseNormalMatrix != null) {
         material.uniforms.inverseNormalMatrix.value.copy(inverseNormalMatrix)
+      }
+      if (material.uniforms.isOrthographic != null) {
+        material.uniforms.isOrthographic.value = this.isOrthographicMode
       }
     })
   }
@@ -869,7 +904,8 @@ export default class Visualizer {
   public initPostProcessing = (
     settings?: Partial<PostProcessingSettings>
   ): void => {
-    this.renderer.initPostProcessing(this.scene, this.camera, settings)
+    // Post-processing (SSAO) requires perspective camera
+    this.renderer.initPostProcessing(this.scene, this.perspectiveCamera, settings)
     this.forceRender = true
   }
 
@@ -925,5 +961,74 @@ export default class Visualizer {
     this.updatePostProcessingSettings({
       ssao: { ...currentSettings.ssao, enabled }
     })
+  }
+
+  /**
+   * Enable or disable orthographic projection mode.
+   * In orthographic mode, objects appear the same size regardless of distance.
+   *
+   * @param enabled - Whether to enable orthographic projection
+   *
+   * @example
+   * ```typescript
+   * visualizer.setOrthographic(true)  // Switch to orthographic
+   * visualizer.setOrthographic(false) // Switch back to perspective
+   * ```
+   */
+  public setOrthographic = (enabled: boolean): void => {
+    if (this.isOrthographicMode === enabled) {
+      return // No change needed
+    }
+
+    this.isOrthographicMode = enabled
+
+    // Get current camera state
+    const currentPosition = this.camera.position.clone()
+    const currentTarget = this.controls.getState().target.clone()
+
+    // Switch to the appropriate camera
+    if (enabled) {
+      // Copy position from perspective camera to orthographic
+      this.orthographicCamera.position.copy(currentPosition)
+      this.orthographicCamera.lookAt(currentTarget)
+
+      // Adjust orthographic frustum based on distance to target
+      const distance = currentPosition.distanceTo(currentTarget)
+      const frustumSize = distance * 0.5 // Scale factor for orthographic view
+      const rendererSize = this.renderer.getSize()
+      const aspect = rendererSize.width / rendererSize.height
+
+      this.orthographicCamera.left = (-frustumSize * aspect) / 2
+      this.orthographicCamera.right = (frustumSize * aspect) / 2
+      this.orthographicCamera.top = frustumSize / 2
+      this.orthographicCamera.bottom = -frustumSize / 2
+      this.orthographicCamera.updateProjectionMatrix()
+
+      this.camera = this.orthographicCamera
+    } else {
+      // Copy position from orthographic camera to perspective
+      this.perspectiveCamera.position.copy(currentPosition)
+      this.perspectiveCamera.lookAt(currentTarget)
+      this.perspectiveCamera.updateProjectionMatrix()
+
+      this.camera = this.perspectiveCamera
+    }
+
+    // Update controls to use the new camera
+    this.controls.setCamera(this.camera)
+
+    // Update input handler camera reference
+    this.inputHandler.setCamera(this.camera)
+
+    this.forceRender = true
+  }
+
+  /**
+   * Check if orthographic projection mode is enabled.
+   *
+   * @returns True if orthographic mode is active
+   */
+  public isOrthographic = (): boolean => {
+    return this.isOrthographicMode
   }
 }


### PR DESCRIPTION
## Summary

Adds support for orthographic projection mode to omovi, allowing users to view molecular structures without perspective distortion. Objects appear the same size regardless of distance, which is useful for technical illustrations and measurements.

## Changes

### Core Features
- Add orthographic camera alongside existing perspective camera
- Add `setOrthographic(enabled: boolean)` method to Visualizer
- Add `isOrthographic()` getter method
- Update particle and bond shaders to support orthographic projection
- Fix billboarding math for orthographic mode (constant view direction that rotates with camera)
- Fix ray-sphere/ray-cylinder intersection for parallel rays in orthographic mode

### Shader Updates
- **Particle shaders**: Extract camera forward direction from `modelViewMatrix` for orthographic billboarding
- **Bond shaders**: Extract camera forward direction from `modelViewMatrix` for orthographic billboarding (note: bonds use opposite direction vector from particles)
- **Fragment shaders**: Use parallel rays `(0, 0, -1)` with origin at fragment position for orthographic, divergent rays from origin for perspective

### Controls
- Reduce orthographic camera zoom/scroll speed (10x slower, from 0.3 to 0.03)
- Fix keyboard W/S movement to use same zoom factor as scroll wheel for orthographic cameras
- Add clamping in `dollyOrthographicCamera` to prevent extreme zoom changes
- Update `adjustCamera` to handle orthographic camera aspect ratio
- Add `setCamera()` method to ComboControls for switching cameras
- Add `setCamera()` method to InputHandler for switching cameras

### Material System
- Add `isOrthographic` uniform to shader materials (injected by Three.js)

### Post-Processing
- Post-processing (SSAO) always uses perspective camera (orthographic mode disables SSAO)

### Code Quality
- Update `updateUniforms` to properly compute `inverseModelMatrix` (was mutating `this.object.matrixWorld` instead)
- Update type signatures to support both camera types throughout the codebase

## Testing

- [x] Particles render correctly in orthographic mode
- [x] Bonds render correctly in orthographic mode
- [x] Camera rotation works correctly (billboards face camera)
- [x] Zoom/scroll speed is appropriate (10x slower than before)
- [x] Keyboard controls work correctly
- [x] Switching between perspective and orthographic modes preserves camera position/target

## Version

Bumped to 0.19.0