### PR TITLE
ci: add Node.js 22.x and 24.x to CI matrix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20.x]
+        node-version: [20.x, 22.x, 24.x]
     
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Changes
Add Node.js 22.x (current LTS) and 24.x (latest LTS) to the CI matrix to ensure compatibility across multiple Node.js versions.

## Versions
- **Node.js 20.x**: Previous LTS, kept for backward compatibility
- **Node.js 22.x**: Current LTS (supported until April 2027)
- **Node.js 24.x**: Latest LTS (supported until April 2028)

This ensures the codebase works correctly across the supported LTS versions.