### PR TITLE
feat: add enable/disable methods for controls and picking

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omovi",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "Online Molecular Visualizer",
   "author": "andeplane",
   "license": "GPLv3",

--- a/src/core/input/InputHandler.ts
+++ b/src/core/input/InputHandler.ts
@@ -37,6 +37,7 @@ export class InputHandler {
   private mouseDownPosition?: { x: number; y: number }
   private mouseDownShiftKey: boolean = false
   private readonly clickDistanceThreshold = CLICK_DISTANCE_THRESHOLD
+  private enabled: boolean = true
 
   /**
    * Create a new InputHandler.
@@ -101,6 +102,15 @@ export class InputHandler {
   }
 
   /**
+   * Enable or disable particle picking.
+   *
+   * @param enabled - Whether picking should be enabled
+   */
+  setEnabled(enabled: boolean): void {
+    this.enabled = enabled
+  }
+
+  /**
    * Clean up event listeners.
    */
   dispose(): void {
@@ -111,12 +121,15 @@ export class InputHandler {
   }
 
   private handleMouseDown = (event: MouseEvent) => {
+    if (!this.enabled) {
+      return
+    }
     this.mouseDownPosition = { x: event.clientX, y: event.clientY }
     this.mouseDownShiftKey = event.shiftKey
   }
 
   private handleMouseUp = (event: MouseEvent) => {
-    if (!this.mouseDownPosition) {
+    if (!this.enabled || !this.mouseDownPosition) {
       return
     }
 
@@ -138,6 +151,9 @@ export class InputHandler {
   }
 
   private handleTouchStart = (event: TouchEvent) => {
+    if (!this.enabled) {
+      return
+    }
     if (event.touches.length > 0) {
       const touch = event.touches[0]
       this.mouseDownPosition = { x: touch.clientX, y: touch.clientY }
@@ -147,7 +163,7 @@ export class InputHandler {
   }
 
   private handleTouchEnd = (event: TouchEvent) => {
-    if (!this.mouseDownPosition) {
+    if (!this.enabled || !this.mouseDownPosition) {
       return
     }
 

--- a/src/core/visualizer.ts
+++ b/src/core/visualizer.ts
@@ -1035,4 +1035,34 @@ export default class Visualizer {
   public isOrthographic = (): boolean => {
     return this.isOrthographicMode
   }
+
+  /**
+   * Enable or disable camera controls.
+   *
+   * @param enabled - Whether camera controls should be enabled
+   *
+   * @example
+   * ```typescript
+   * visualizer.setControlsEnabled(false) // Disable camera controls
+   * visualizer.setControlsEnabled(true)  // Enable camera controls
+   * ```
+   */
+  public setControlsEnabled = (enabled: boolean): void => {
+    this.controls.enabled = enabled
+  }
+
+  /**
+   * Enable or disable particle picking.
+   *
+   * @param enabled - Whether particle picking should be enabled
+   *
+   * @example
+   * ```typescript
+   * visualizer.setPickingEnabled(false) // Disable particle picking
+   * visualizer.setPickingEnabled(true)  // Enable particle picking
+   * ```
+   */
+  public setPickingEnabled = (enabled: boolean): void => {
+    this.inputHandler.setEnabled(enabled)
+  }
 }


### PR DESCRIPTION
## Changes

- Add `setEnabled` method to `InputHandler` to control particle picking
- Add `setControlsEnabled` method to `Visualizer` to control camera controls  
- Add `setPickingEnabled` method to `Visualizer` to control particle picking
- Bump version to 0.21.0

## Details

This PR adds the ability to programmatically enable/disable camera controls and particle picking in the Visualizer. This is useful for scenarios where you want to temporarily disable user interaction, such as during animations or when showing specific views.

The `InputHandler` now checks the `enabled` state before processing any mouse or touch events, preventing picking when disabled.