### PR TITLE
fix: WebXR black screen issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omovi",
-  "version": "0.24.0",
+  "version": "0.25.0",
   "description": "Online Molecular Visualizer",
   "author": "andeplane",
   "license": "GPLv3",

--- a/src/controls/ComboControls.ts
+++ b/src/controls/ComboControls.ts
@@ -380,7 +380,7 @@ export class ComboControls extends EventDispatcher<CameraUpdateEvent> {
     event.preventDefault()
   }
 
-  private rotate = (deltaX: number, deltaY: number) => {
+  public rotate = (deltaX: number, deltaY: number) => {
     if (deltaX === 0 && deltaY === 0) {
       return
     }
@@ -785,7 +785,7 @@ export class ComboControls extends EventDispatcher<CameraUpdateEvent> {
     targetEnd.add(targetOffset)
   }
 
-  private dolly = (x: number, y: number, deltaDistance: number) => {
+  public dolly = (x: number, y: number, deltaDistance: number) => {
     const { camera } = this
     if (camera instanceof THREE.OrthographicCamera) {
       this.dollyOrthographicCamera(x, y, deltaDistance)
@@ -794,7 +794,7 @@ export class ComboControls extends EventDispatcher<CameraUpdateEvent> {
     }
   }
 
-  private getDollyDeltaDistance = (dollyIn: boolean, steps: number = 1) => {
+  public getDollyDeltaDistance = (dollyIn: boolean, steps: number = 1) => {
     const { sphericalEnd, dollyFactor } = this
     const zoomFactor = dollyFactor ** steps
     const factor = dollyIn ? zoomFactor : 1 / zoomFactor

--- a/src/core/XRHandController.test.ts
+++ b/src/core/XRHandController.test.ts
@@ -1,0 +1,642 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import * as THREE from 'three'
+import { XRHandController, XRHandControllerCallbacks } from './XRHandController'
+
+// Helper to create a mock WebGLRenderer
+function createMockRenderer(): Partial<THREE.WebGLRenderer> {
+  return {}
+}
+
+// Helper to create a mock reference space
+function createMockReferenceSpace(): Partial<XRReferenceSpace> {
+  return {}
+}
+
+// Helper to create a joint pose with position
+function createJointPose(
+  x: number,
+  y: number,
+  z: number
+): Partial<XRJointPose> {
+  const position: Partial<DOMPointReadOnly> = { x, y, z, w: 1 }
+  const fullPosition: DOMPointReadOnly = position as DOMPointReadOnly
+  const transform: Partial<XRRigidTransform> = { position: fullPosition }
+  const fullTransform: XRRigidTransform = transform as XRRigidTransform
+  const pose: Partial<XRJointPose> = { transform: fullTransform }
+  return pose
+}
+
+// Helper to create joint positions for a hand
+function createJointPositions(
+  thumbX: number,
+  thumbY: number,
+  thumbZ: number,
+  indexX: number,
+  indexY: number,
+  indexZ: number
+): { thumb: Partial<XRJointPose>; index: Partial<XRJointPose> } {
+  return {
+    thumb: createJointPose(thumbX, thumbY, thumbZ),
+    index: createJointPose(indexX, indexY, indexZ)
+  }
+}
+
+// Helper to create a mock joint space
+function createJointSpace(jointName: XRHandJoint): Partial<XRJointSpace> {
+  return { jointName }
+}
+
+// Helper to create a mock hand with specific joint positions
+function createMockHand(): Partial<XRHand> {
+  const jointMap: Record<string, Partial<XRJointSpace>> = {
+    'thumb-tip': createJointSpace('thumb-tip'),
+    'index-finger-tip': createJointSpace('index-finger-tip')
+  }
+
+  const hand: Partial<XRHand> = {
+    get: (jointName: XRHandJoint) => {
+      const joint: XRJointSpace | undefined = jointMap[jointName] as
+        | XRJointSpace
+        | undefined
+      return joint
+    },
+    size: 2,
+    forEach: vi.fn(),
+    entries: vi.fn(),
+    keys: vi.fn(),
+    values: vi.fn(),
+    [Symbol.iterator]: vi.fn()
+  }
+  return hand
+}
+
+// Helper to create a mock input source
+function createInputSource(
+  handedness: 'left' | 'right',
+  hand: Partial<XRHand>
+): Partial<XRInputSource> {
+  const fullHand: XRHand = hand as XRHand
+  const inputSource: Partial<XRInputSource> = {
+    hand: fullHand,
+    handedness,
+    targetRayMode: 'tracked-pointer'
+  }
+  return inputSource
+}
+
+// Helper to create a mock XR frame with hands
+function createMockFrame(
+  hands: Array<{
+    handedness: 'left' | 'right'
+    joints: { thumb: Partial<XRJointPose>; index: Partial<XRJointPose> }
+  }>
+): Partial<XRFrame> {
+  const inputSources: Partial<XRInputSource>[] = hands.map(({ handedness }) =>
+    createInputSource(handedness, createMockHand())
+  )
+
+  // Create a map to look up joint poses by hand
+  const jointPoseMap = new Map<string, Partial<XRJointPose>>()
+  hands.forEach(({ handedness, joints }) => {
+    jointPoseMap.set(`${handedness}-thumb-tip`, joints.thumb)
+    jointPoseMap.set(`${handedness}-index-finger-tip`, joints.index)
+  })
+
+  const fullInputSources: XRInputSourceArray =
+    inputSources as XRInputSourceArray
+  const session: Partial<XRSession> = {
+    inputSources: fullInputSources
+  }
+
+  const fullSession: XRSession = session as XRSession
+  const thumbTipJoint: XRHandJoint = 'thumb-tip'
+  const indexTipJoint: XRHandJoint = 'index-finger-tip'
+
+  const frame: Partial<XRFrame> = {
+    session: fullSession,
+    getJointPose: (
+      joint: XRJointSpace,
+      _referenceSpace: XRSpace
+    ): XRJointPose | undefined => {
+      // Find which hand this joint belongs to by checking input sources
+      for (const source of inputSources) {
+        if (!source.hand) continue
+        const hand = source.hand
+        const thumbJoint = hand.get(thumbTipJoint)
+        const indexJoint = hand.get(indexTipJoint)
+
+        if (joint === thumbJoint) {
+          const pose: XRJointPose | undefined = jointPoseMap.get(
+            `${source.handedness}-thumb-tip`
+          ) as XRJointPose | undefined
+          return pose
+        }
+        if (joint === indexJoint) {
+          const pose: XRJointPose | undefined = jointPoseMap.get(
+            `${source.handedness}-index-finger-tip`
+          ) as XRJointPose | undefined
+          return pose
+        }
+      }
+      return undefined
+    }
+  }
+  return frame
+}
+
+// Helper to create pinching hand positions (below threshold)
+function createPinchingJoints(): {
+  thumb: Partial<XRJointPose>
+  index: Partial<XRJointPose>
+} {
+  // Distance = 0.01m (1cm), below threshold of 2.5cm
+  return createJointPositions(0, 0, 0, 0.01, 0, 0)
+}
+
+// Helper to create non-pinching hand positions (above threshold)
+function createNonPinchingJoints(): {
+  thumb: Partial<XRJointPose>
+  index: Partial<XRJointPose>
+} {
+  // Distance = 0.05m (5cm), above threshold of 2.5cm
+  return createJointPositions(0, 0, 0, 0.05, 0, 0)
+}
+
+describe('XRHandController', () => {
+  let mockRenderer: Partial<THREE.WebGLRenderer>
+  let mockReferenceSpace: Partial<XRReferenceSpace>
+  let callbacks: XRHandControllerCallbacks
+
+  beforeEach(() => {
+    mockRenderer = createMockRenderer()
+    mockReferenceSpace = createMockReferenceSpace()
+    callbacks = {
+      onPinchStart: vi.fn(),
+      onPinchMove: vi.fn(),
+      onPinchEnd: vi.fn(),
+      onZoom: vi.fn()
+    }
+  })
+
+  describe('constructor', () => {
+    it('should create instance with renderer and callbacks', () => {
+      // Arrange & Act
+      const controller = new XRHandController(
+        mockRenderer as THREE.WebGLRenderer,
+        callbacks
+      )
+
+      // Assert
+      expect(controller).toBeInstanceOf(XRHandController)
+    })
+
+    it('should create instance with renderer only (no callbacks)', () => {
+      // Arrange & Act
+      const controller = new XRHandController(
+        mockRenderer as THREE.WebGLRenderer
+      )
+
+      // Assert
+      expect(controller).toBeInstanceOf(XRHandController)
+    })
+  })
+
+  describe('update', () => {
+    it('should return early when frame is null', () => {
+      // Arrange
+      const controller = new XRHandController(
+        mockRenderer as THREE.WebGLRenderer,
+        callbacks
+      )
+
+      // Act
+      controller.update(null, mockReferenceSpace as XRReferenceSpace)
+
+      // Assert
+      expect(callbacks.onPinchStart).not.toHaveBeenCalled()
+      expect(callbacks.onPinchMove).not.toHaveBeenCalled()
+      expect(callbacks.onPinchEnd).not.toHaveBeenCalled()
+    })
+
+    it('should return early when referenceSpace is null', () => {
+      // Arrange
+      const controller = new XRHandController(
+        mockRenderer as THREE.WebGLRenderer,
+        callbacks
+      )
+      const mockFrame = createMockFrame([])
+
+      // Act
+      controller.update(mockFrame as XRFrame, null)
+
+      // Assert
+      expect(callbacks.onPinchStart).not.toHaveBeenCalled()
+    })
+
+    it('should detect pinch when thumb-index distance is below threshold', () => {
+      // Arrange
+      const controller = new XRHandController(
+        mockRenderer as THREE.WebGLRenderer,
+        callbacks
+      )
+      const mockFrame = createMockFrame([
+        { handedness: 'right', joints: createPinchingJoints() }
+      ])
+
+      // Act
+      controller.update(
+        mockFrame as XRFrame,
+        mockReferenceSpace as XRReferenceSpace
+      )
+
+      // Assert
+      expect(callbacks.onPinchStart).toHaveBeenCalledTimes(1)
+      expect(callbacks.onPinchStart).toHaveBeenCalledWith(
+        expect.objectContaining({
+          hand: 'right',
+          position: expect.any(THREE.Vector3)
+        })
+      )
+    })
+
+    it('should not detect pinch when distance is above threshold', () => {
+      // Arrange
+      const controller = new XRHandController(
+        mockRenderer as THREE.WebGLRenderer,
+        callbacks
+      )
+      const mockFrame = createMockFrame([
+        { handedness: 'right', joints: createNonPinchingJoints() }
+      ])
+
+      // Act
+      controller.update(
+        mockFrame as XRFrame,
+        mockReferenceSpace as XRReferenceSpace
+      )
+
+      // Assert
+      expect(callbacks.onPinchStart).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('pinch callbacks', () => {
+    it.each(['left', 'right'] as const)(
+      'should call onPinchStart when %s hand begins pinching',
+      (handedness) => {
+        // Arrange
+        const controller = new XRHandController(
+          mockRenderer as THREE.WebGLRenderer,
+          callbacks
+        )
+        const mockFrame = createMockFrame([
+          { handedness, joints: createPinchingJoints() }
+        ])
+
+        // Act
+        controller.update(
+          mockFrame as XRFrame,
+          mockReferenceSpace as XRReferenceSpace
+        )
+
+        // Assert
+        expect(callbacks.onPinchStart).toHaveBeenCalledWith(
+          expect.objectContaining({
+            hand: handedness,
+            position: expect.any(THREE.Vector3),
+            delta: expect.any(THREE.Vector3)
+          })
+        )
+      }
+    )
+
+    it.each(['left', 'right'] as const)(
+      'should call onPinchMove with delta when %s hand continues pinching',
+      (handedness) => {
+        // Arrange
+        const controller = new XRHandController(
+          mockRenderer as THREE.WebGLRenderer,
+          callbacks
+        )
+
+        // First frame - start pinch at origin
+        const initialJoints = createJointPositions(0, 0, 0, 0.01, 0, 0)
+        const frame1 = createMockFrame([{ handedness, joints: initialJoints }])
+        controller.update(
+          frame1 as XRFrame,
+          mockReferenceSpace as XRReferenceSpace
+        )
+
+        // Second frame - move pinch position
+        const movedJoints = createJointPositions(0.1, 0.1, 0, 0.11, 0.1, 0)
+        const frame2 = createMockFrame([{ handedness, joints: movedJoints }])
+
+        // Act
+        controller.update(
+          frame2 as XRFrame,
+          mockReferenceSpace as XRReferenceSpace
+        )
+
+        // Assert
+        expect(callbacks.onPinchMove).toHaveBeenCalledWith(
+          expect.objectContaining({
+            hand: handedness,
+            position: expect.any(THREE.Vector3),
+            delta: expect.any(THREE.Vector3)
+          })
+        )
+      }
+    )
+
+    it.each(['left', 'right'] as const)(
+      'should call onPinchEnd when %s hand releases pinch',
+      (handedness) => {
+        // Arrange
+        const controller = new XRHandController(
+          mockRenderer as THREE.WebGLRenderer,
+          callbacks
+        )
+
+        // First frame - start pinch
+        const pinchFrame = createMockFrame([
+          { handedness, joints: createPinchingJoints() }
+        ])
+        controller.update(
+          pinchFrame as XRFrame,
+          mockReferenceSpace as XRReferenceSpace
+        )
+
+        // Second frame - release pinch
+        const releaseFrame = createMockFrame([
+          { handedness, joints: createNonPinchingJoints() }
+        ])
+
+        // Act
+        controller.update(
+          releaseFrame as XRFrame,
+          mockReferenceSpace as XRReferenceSpace
+        )
+
+        // Assert
+        expect(callbacks.onPinchEnd).toHaveBeenCalledWith(
+          expect.objectContaining({
+            hand: handedness,
+            position: expect.any(THREE.Vector3),
+            delta: expect.any(THREE.Vector3)
+          })
+        )
+      }
+    )
+
+    it('should handle left and right hand independently', () => {
+      // Arrange
+      const controller = new XRHandController(
+        mockRenderer as THREE.WebGLRenderer,
+        callbacks
+      )
+      const mockFrame = createMockFrame([
+        { handedness: 'left', joints: createPinchingJoints() },
+        { handedness: 'right', joints: createNonPinchingJoints() }
+      ])
+
+      // Act
+      controller.update(
+        mockFrame as XRFrame,
+        mockReferenceSpace as XRReferenceSpace
+      )
+
+      // Assert
+      expect(callbacks.onPinchStart).toHaveBeenCalledTimes(1)
+      expect(callbacks.onPinchStart).toHaveBeenCalledWith(
+        expect.objectContaining({ hand: 'left' })
+      )
+    })
+  })
+
+  describe('two-hand zoom', () => {
+    it('should call onZoom when both hands are pinching', () => {
+      // Arrange
+      const controller = new XRHandController(
+        mockRenderer as THREE.WebGLRenderer,
+        callbacks
+      )
+
+      // First frame - establish initial hand positions
+      const leftJoints = createJointPositions(-0.1, 0, 0, -0.09, 0, 0)
+      const rightJoints = createJointPositions(0.1, 0, 0, 0.11, 0, 0)
+      const frame1 = createMockFrame([
+        { handedness: 'left', joints: leftJoints },
+        { handedness: 'right', joints: rightJoints }
+      ])
+      controller.update(
+        frame1 as XRFrame,
+        mockReferenceSpace as XRReferenceSpace
+      )
+
+      // Second frame - both hands pinching, same positions
+      const frame2 = createMockFrame([
+        { handedness: 'left', joints: leftJoints },
+        { handedness: 'right', joints: rightJoints }
+      ])
+
+      // Act
+      controller.update(
+        frame2 as XRFrame,
+        mockReferenceSpace as XRReferenceSpace
+      )
+
+      // Assert
+      expect(callbacks.onZoom).toHaveBeenCalled()
+    })
+
+    it('should calculate correct scale factor from hand distance change', () => {
+      // Arrange
+      const controller = new XRHandController(
+        mockRenderer as THREE.WebGLRenderer,
+        callbacks
+      )
+
+      // First frame - hands 20cm apart (pinch positions at -0.095 and 0.105)
+      const leftJoints1 = createJointPositions(-0.1, 0, 0, -0.09, 0, 0)
+      const rightJoints1 = createJointPositions(0.1, 0, 0, 0.11, 0, 0)
+      const frame1 = createMockFrame([
+        { handedness: 'left', joints: leftJoints1 },
+        { handedness: 'right', joints: rightJoints1 }
+      ])
+      controller.update(
+        frame1 as XRFrame,
+        mockReferenceSpace as XRReferenceSpace
+      )
+
+      // Second frame - hands 40cm apart (double the distance)
+      const leftJoints2 = createJointPositions(-0.2, 0, 0, -0.19, 0, 0)
+      const rightJoints2 = createJointPositions(0.2, 0, 0, 0.21, 0, 0)
+      const frame2 = createMockFrame([
+        { handedness: 'left', joints: leftJoints2 },
+        { handedness: 'right', joints: rightJoints2 }
+      ])
+
+      // Act
+      controller.update(
+        frame2 as XRFrame,
+        mockReferenceSpace as XRReferenceSpace
+      )
+
+      // Assert
+      expect(callbacks.onZoom).toHaveBeenCalledWith(
+        expect.objectContaining({
+          scale: expect.any(Number),
+          centerPosition: expect.any(THREE.Vector3)
+        })
+      )
+      const zoomCall = vi.mocked(callbacks.onZoom!).mock.calls[0][0]
+      expect(zoomCall.scale).toBeGreaterThan(1) // Zooming out (hands moved apart)
+    })
+
+    it('should not call onZoom when only one hand is pinching', () => {
+      // Arrange
+      const controller = new XRHandController(
+        mockRenderer as THREE.WebGLRenderer,
+        callbacks
+      )
+      const mockFrame = createMockFrame([
+        { handedness: 'left', joints: createPinchingJoints() },
+        { handedness: 'right', joints: createNonPinchingJoints() }
+      ])
+
+      // Act
+      controller.update(
+        mockFrame as XRFrame,
+        mockReferenceSpace as XRReferenceSpace
+      )
+
+      // Assert
+      expect(callbacks.onZoom).not.toHaveBeenCalled()
+    })
+
+    it('should not call onZoom when neither hand is pinching', () => {
+      // Arrange
+      const controller = new XRHandController(
+        mockRenderer as THREE.WebGLRenderer,
+        callbacks
+      )
+      const mockFrame = createMockFrame([
+        { handedness: 'left', joints: createNonPinchingJoints() },
+        { handedness: 'right', joints: createNonPinchingJoints() }
+      ])
+
+      // Act
+      controller.update(
+        mockFrame as XRFrame,
+        mockReferenceSpace as XRReferenceSpace
+      )
+
+      // Assert
+      expect(callbacks.onZoom).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('state queries', () => {
+    it('isAnyHandPinching should return false initially', () => {
+      // Arrange
+      const controller = new XRHandController(
+        mockRenderer as THREE.WebGLRenderer,
+        callbacks
+      )
+
+      // Act & Assert
+      expect(controller.isAnyHandPinching()).toBe(false)
+    })
+
+    it.each(['left', 'right'] as const)(
+      'isAnyHandPinching should return true when %s hand is pinching',
+      (handedness) => {
+        // Arrange
+        const controller = new XRHandController(
+          mockRenderer as THREE.WebGLRenderer,
+          callbacks
+        )
+        const mockFrame = createMockFrame([
+          { handedness, joints: createPinchingJoints() }
+        ])
+
+        // Act
+        controller.update(
+          mockFrame as XRFrame,
+          mockReferenceSpace as XRReferenceSpace
+        )
+
+        // Assert
+        expect(controller.isAnyHandPinching()).toBe(true)
+      }
+    )
+
+    it('isBothHandsPinching should return false when only one hand is pinching', () => {
+      // Arrange
+      const controller = new XRHandController(
+        mockRenderer as THREE.WebGLRenderer,
+        callbacks
+      )
+      const mockFrame = createMockFrame([
+        { handedness: 'left', joints: createPinchingJoints() },
+        { handedness: 'right', joints: createNonPinchingJoints() }
+      ])
+
+      // Act
+      controller.update(
+        mockFrame as XRFrame,
+        mockReferenceSpace as XRReferenceSpace
+      )
+
+      // Assert
+      expect(controller.isBothHandsPinching()).toBe(false)
+    })
+
+    it('isBothHandsPinching should return true when both hands are pinching', () => {
+      // Arrange
+      const controller = new XRHandController(
+        mockRenderer as THREE.WebGLRenderer,
+        callbacks
+      )
+      const mockFrame = createMockFrame([
+        { handedness: 'left', joints: createPinchingJoints() },
+        { handedness: 'right', joints: createPinchingJoints() }
+      ])
+
+      // Act
+      controller.update(
+        mockFrame as XRFrame,
+        mockReferenceSpace as XRReferenceSpace
+      )
+
+      // Assert
+      expect(controller.isBothHandsPinching()).toBe(true)
+    })
+  })
+
+  describe('dispose', () => {
+    it('should reset all pinch states to false', () => {
+      // Arrange
+      const controller = new XRHandController(
+        mockRenderer as THREE.WebGLRenderer,
+        callbacks
+      )
+      const mockFrame = createMockFrame([
+        { handedness: 'left', joints: createPinchingJoints() },
+        { handedness: 'right', joints: createPinchingJoints() }
+      ])
+      controller.update(
+        mockFrame as XRFrame,
+        mockReferenceSpace as XRReferenceSpace
+      )
+      expect(controller.isBothHandsPinching()).toBe(true) // Verify state is set
+
+      // Act
+      controller.dispose()
+
+      // Assert
+      expect(controller.isAnyHandPinching()).toBe(false)
+      expect(controller.isBothHandsPinching()).toBe(false)
+    })
+  })
+})

--- a/src/core/XRHandController.ts
+++ b/src/core/XRHandController.ts
@@ -1,0 +1,267 @@
+import * as THREE from 'three'
+
+/**
+ * Joint names for WebXR hand tracking
+ */
+const THUMB_TIP = 'thumb-tip'
+const INDEX_TIP = 'index-finger-tip'
+
+/**
+ * Pinch detection threshold in meters (2.5cm)
+ */
+const PINCH_THRESHOLD = 0.025
+
+/**
+ * State of a single hand's pinch gesture
+ */
+interface HandPinchState {
+  isPinching: boolean
+  pinchPosition: THREE.Vector3
+  previousPinchPosition: THREE.Vector3
+}
+
+/**
+ * Event data for pinch gestures
+ */
+export interface PinchEvent {
+  hand: 'left' | 'right'
+  position: THREE.Vector3
+  delta: THREE.Vector3
+}
+
+/**
+ * Event data for two-hand zoom gestures
+ */
+export interface ZoomEvent {
+  scale: number
+  centerPosition: THREE.Vector3
+}
+
+/**
+ * Callback types for gesture events
+ */
+export interface XRHandControllerCallbacks {
+  onPinchStart?: (event: PinchEvent) => void
+  onPinchMove?: (event: PinchEvent) => void
+  onPinchEnd?: (event: PinchEvent) => void
+  onZoom?: (event: ZoomEvent) => void
+}
+
+/**
+ * Controller for WebXR hand tracking with pinch gesture detection.
+ * Supports single-hand pinch for panning and two-hand pinch for zooming.
+ */
+export class XRHandController {
+  private renderer: THREE.WebGLRenderer
+  private callbacks: XRHandControllerCallbacks
+
+  // Hand state tracking
+  private leftHand: HandPinchState = {
+    isPinching: false,
+    pinchPosition: new THREE.Vector3(),
+    previousPinchPosition: new THREE.Vector3()
+  }
+  private rightHand: HandPinchState = {
+    isPinching: false,
+    pinchPosition: new THREE.Vector3(),
+    previousPinchPosition: new THREE.Vector3()
+  }
+
+  // Two-hand zoom tracking
+  private previousHandDistance: number = 0
+  private isTwoHandZooming: boolean = false
+
+  // Reusable vectors to avoid allocations
+  private _thumbPos = new THREE.Vector3()
+  private _indexPos = new THREE.Vector3()
+  private _delta = new THREE.Vector3()
+  private _center = new THREE.Vector3()
+
+  // Debug flag
+  private _hasLoggedInputSources = false
+
+  constructor(renderer: THREE.WebGLRenderer, callbacks: XRHandControllerCallbacks = {}) {
+    this.renderer = renderer
+    this.callbacks = callbacks
+  }
+
+  /**
+   * Update hand tracking state. Call this every frame when XR is presenting.
+   */
+  update(frame: XRFrame | null, referenceSpace: XRReferenceSpace | null): void {
+    if (!frame || !referenceSpace) return
+
+    const session = frame.session
+    const inputSources = session.inputSources
+
+    // Debug: log input sources on first call
+    if (!this._hasLoggedInputSources) {
+      console.log('XR Input Sources:', inputSources.length)
+      for (const source of inputSources) {
+        console.log('  - handedness:', source.handedness, 'hand:', !!source.hand, 'targetRayMode:', source.targetRayMode)
+      }
+      this._hasLoggedInputSources = true
+    }
+
+    let leftHandData: { isPinching: boolean; position: THREE.Vector3 } | null = null
+    let rightHandData: { isPinching: boolean; position: THREE.Vector3 } | null = null
+
+    // Process each input source (hand)
+    for (const inputSource of inputSources) {
+      if (!inputSource.hand) continue
+
+      const handedness = inputSource.handedness
+      const hand = inputSource.hand
+
+      // Get thumb and index finger tip positions
+      const thumbTip = hand.get(THUMB_TIP as XRHandJoint)
+      const indexTip = hand.get(INDEX_TIP as XRHandJoint)
+
+      if (!thumbTip || !indexTip) continue
+
+      const thumbPose = frame.getJointPose?.(thumbTip, referenceSpace)
+      const indexPose = frame.getJointPose?.(indexTip, referenceSpace)
+
+      if (!thumbPose || !indexPose) continue
+
+      // Get positions
+      this._thumbPos.set(
+        thumbPose.transform.position.x,
+        thumbPose.transform.position.y,
+        thumbPose.transform.position.z
+      )
+      this._indexPos.set(
+        indexPose.transform.position.x,
+        indexPose.transform.position.y,
+        indexPose.transform.position.z
+      )
+
+      // Calculate pinch distance
+      const pinchDistance = this._thumbPos.distanceTo(this._indexPos)
+      const isPinching = pinchDistance < PINCH_THRESHOLD
+
+      // Calculate pinch position (midpoint between thumb and index)
+      const pinchPosition = new THREE.Vector3()
+        .addVectors(this._thumbPos, this._indexPos)
+        .multiplyScalar(0.5)
+
+      if (handedness === 'left') {
+        leftHandData = { isPinching, position: pinchPosition }
+        this.processHandPinch('left', this.leftHand, isPinching, pinchPosition)
+      } else if (handedness === 'right') {
+        rightHandData = { isPinching, position: pinchPosition }
+        this.processHandPinch('right', this.rightHand, isPinching, pinchPosition)
+      }
+    }
+
+    // Check for two-hand zoom
+    this.processTwoHandZoom(leftHandData, rightHandData)
+  }
+
+  /**
+   * Process pinch state for a single hand
+   */
+  private processHandPinch(
+    handedness: 'left' | 'right',
+    handState: HandPinchState,
+    isPinching: boolean,
+    position: THREE.Vector3
+  ): void {
+    if (isPinching && !handState.isPinching) {
+      // Pinch started
+      handState.isPinching = true
+      handState.pinchPosition.copy(position)
+      handState.previousPinchPosition.copy(position)
+
+      this.callbacks.onPinchStart?.({
+        hand: handedness,
+        position: position.clone(),
+        delta: new THREE.Vector3()
+      })
+    } else if (isPinching && handState.isPinching) {
+      // Pinch continuing - calculate delta
+      this._delta.subVectors(position, handState.previousPinchPosition)
+
+      handState.previousPinchPosition.copy(handState.pinchPosition)
+      handState.pinchPosition.copy(position)
+
+      this.callbacks.onPinchMove?.({
+        hand: handedness,
+        position: position.clone(),
+        delta: this._delta.clone()
+      })
+    } else if (!isPinching && handState.isPinching) {
+      // Pinch ended
+      handState.isPinching = false
+
+      this.callbacks.onPinchEnd?.({
+        hand: handedness,
+        position: handState.pinchPosition.clone(),
+        delta: new THREE.Vector3()
+      })
+    }
+  }
+
+  /**
+   * Process two-hand zoom gesture
+   */
+  private processTwoHandZoom(
+    leftHandData: { isPinching: boolean; position: THREE.Vector3 } | null,
+    rightHandData: { isPinching: boolean; position: THREE.Vector3 } | null
+  ): void {
+    const bothPinching =
+      leftHandData?.isPinching && rightHandData?.isPinching
+
+    if (bothPinching && leftHandData && rightHandData) {
+      const currentDistance = leftHandData.position.distanceTo(rightHandData.position)
+
+      if (this.isTwoHandZooming) {
+        // Calculate scale factor
+        const scale = currentDistance / this.previousHandDistance
+
+        // Calculate center point between hands
+        this._center
+          .addVectors(leftHandData.position, rightHandData.position)
+          .multiplyScalar(0.5)
+
+        this.callbacks.onZoom?.({
+          scale,
+          centerPosition: this._center.clone()
+        })
+      }
+
+      this.previousHandDistance = currentDistance
+      this.isTwoHandZooming = true
+    } else {
+      this.isTwoHandZooming = false
+      this.previousHandDistance = 0
+    }
+  }
+
+  /**
+   * Check if any hand is currently pinching
+   */
+  isAnyHandPinching(): boolean {
+    return this.leftHand.isPinching || this.rightHand.isPinching
+  }
+
+  /**
+   * Check if both hands are pinching (zoom gesture)
+   */
+  isBothHandsPinching(): boolean {
+    return this.leftHand.isPinching && this.rightHand.isPinching
+  }
+
+  /**
+   * Clean up resources
+   */
+  dispose(): void {
+    // Reset state
+    this.leftHand.isPinching = false
+    this.rightHand.isPinching = false
+    this.isTwoHandZooming = false
+  }
+}
+
+export default XRHandController
+

--- a/src/core/XRHandController.ts
+++ b/src/core/XRHandController.ts
@@ -17,7 +17,6 @@ const PINCH_THRESHOLD = 0.025
 interface HandPinchState {
   isPinching: boolean
   pinchPosition: THREE.Vector3
-  previousPinchPosition: THREE.Vector3
 }
 
 /**
@@ -58,13 +57,11 @@ export class XRHandController {
   // Hand state tracking
   private leftHand: HandPinchState = {
     isPinching: false,
-    pinchPosition: new THREE.Vector3(),
-    previousPinchPosition: new THREE.Vector3()
+    pinchPosition: new THREE.Vector3()
   }
   private rightHand: HandPinchState = {
     isPinching: false,
-    pinchPosition: new THREE.Vector3(),
-    previousPinchPosition: new THREE.Vector3()
+    pinchPosition: new THREE.Vector3()
   }
 
   // Two-hand zoom tracking
@@ -178,7 +175,6 @@ export class XRHandController {
       // Pinch started
       handState.isPinching = true
       handState.pinchPosition.copy(position)
-      handState.previousPinchPosition.copy(position)
 
       this.callbacks.onPinchStart?.({
         hand: handedness,
@@ -186,10 +182,9 @@ export class XRHandController {
         delta: new THREE.Vector3()
       })
     } else if (isPinching && handState.isPinching) {
-      // Pinch continuing - calculate delta
-      this._delta.subVectors(position, handState.previousPinchPosition)
+      // Pinch continuing - calculate delta from previous frame's position
+      this._delta.subVectors(position, handState.pinchPosition)
 
-      handState.previousPinchPosition.copy(handState.pinchPosition)
       handState.pinchPosition.copy(position)
 
       this.callbacks.onPinchMove?.({

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -45,3 +45,33 @@ export const DEFAULT_CAMERA_NEAR = 0.1
  * Default camera far clipping plane
  */
 export const DEFAULT_CAMERA_FAR = 10000
+
+/**
+ * XR hand gesture rotation sensitivity
+ */
+export const XR_ROTATE_SCALE = 2.6
+
+/**
+ * XR zoom steps multiplier for pinch gesture
+ */
+export const XR_ZOOM_STEPS_MULTIPLIER = 50
+
+/**
+ * XR zoom delta scale factor (slower for smoother control)
+ */
+export const XR_ZOOM_DELTA_SCALE = 0.5
+
+/**
+ * XR minimum camera radius from target
+ */
+export const XR_MIN_RADIUS = 1
+
+/**
+ * XR maximum camera radius from target
+ */
+export const XR_MAX_RADIUS = 1000
+
+/**
+ * XR spherical phi clamp epsilon (to avoid gimbal lock at poles)
+ */
+export const XR_PHI_EPSILON = 0.1

--- a/src/core/renderer.ts
+++ b/src/core/renderer.ts
@@ -211,9 +211,8 @@ export default class OMOVIRenderer {
     this.onBeforeModelRender()
 
     // In XR mode, render directly without intermediate targets or post-processing
-    // WebXR handles stereo rendering internally and requires direct framebuffer access
+    // WebXR handles stereo rendering internally - don't touch render targets
     if (this.renderer.xr.isPresenting) {
-      this.renderer.setRenderTarget(null)
       this.renderer.render(scene, camera)
       this.onAfterRender()
       return

--- a/src/core/visualizer.ts
+++ b/src/core/visualizer.ts
@@ -718,11 +718,17 @@ export default class Visualizer {
   }
 
   animate = () => {
+    const isXRPresenting = this.renderer.getRawRenderer().xr.isPresenting
+
     if (!this.idle) {
       this.memoryStats.update()
       this.cpuStats.begin()
-      this.resizeIfNeeded()
-      this.controls.update(this.clock.getDelta())
+
+      // Skip resize and controls in XR mode - XR system handles these
+      if (!isXRPresenting) {
+        this.resizeIfNeeded()
+        this.controls.update(this.clock.getDelta())
+      }
 
       this.updateUniforms(this.camera)
 
@@ -759,7 +765,6 @@ export default class Visualizer {
       } else {
         // Check if we need outline post-processing
         const needsOutline = this.hasSelection()
-        const isXRPresenting = this.renderer.getRawRenderer().xr.isPresenting
 
         // Always render with SSAO first
         this.renderer.render(this.scene, this.camera)

--- a/src/core/visualizer.ts
+++ b/src/core/visualizer.ts
@@ -268,6 +268,13 @@ export default class Visualizer {
     this.object = new THREE.Object3D()
     this.scene.add(this.object)
 
+    // DEBUG: Add a test cube to verify XR rendering works
+    const testGeometry = new THREE.BoxGeometry(5, 5, 5)
+    const testMaterial = new THREE.MeshBasicMaterial({ color: 0xff0000 })
+    const testCube = new THREE.Mesh(testGeometry, testMaterial)
+    testCube.position.set(0, 0, 0) // At origin where particles usually are
+    this.scene.add(testCube)
+
     this.cpuStats = new Stats()
     this.memoryStats = new Stats()
     this.cpuStats.showPanel(0) // 0: fps, 1: ms, 2: mb, 3+: custom
@@ -728,9 +735,8 @@ export default class Visualizer {
       if (!isXRPresenting) {
         this.resizeIfNeeded()
         this.controls.update(this.clock.getDelta())
+        this.updateUniforms(this.camera)
       }
-
-      this.updateUniforms(this.camera)
 
       // If debug picking is enabled, render with picking material instead
       if (this.debugPickingRender) {

--- a/src/core/visualizer.ts
+++ b/src/core/visualizer.ts
@@ -1169,8 +1169,8 @@ export default class Visualizer {
             const dollyIn = zoomSteps < 0
             const deltaDistance = this.controls.getDollyDeltaDistance(dollyIn, Math.abs(zoomSteps))
 
-            // Apply to spherical radius instead of controls
-            xrSpherical.radius += deltaDistance
+            // Apply to spherical radius instead of controls (50% slower for smoother control)
+            xrSpherical.radius += deltaDistance * 0.5
             // Clamp radius to reasonable bounds
             xrSpherical.radius = Math.max(1, Math.min(1000, xrSpherical.radius))
 

--- a/src/core/visualizer.ts
+++ b/src/core/visualizer.ts
@@ -1217,6 +1217,15 @@ export default class Visualizer {
         this.scene.remove(this.cameraRig)
         this.cameraRig = undefined
       }
+
+      // Reset render target to canvas (XR may have changed it)
+      rawRenderer.setRenderTarget(null)
+
+      // Force camera aspect ratio and render target sizes to match canvas
+      // XR mode may have changed these to match the headset display
+      const rendererSize = this.renderer.getSize()
+      adjustCamera(this.camera, rendererSize.width, rendererSize.height)
+      this.camera.updateProjectionMatrix()
     })
 
     // Request hand tracking as an optional feature for gesture controls

--- a/src/core/visualizer.ts
+++ b/src/core/visualizer.ts
@@ -337,7 +337,7 @@ export default class Visualizer {
     // document.body.appendChild(
     //   VRButton.createButton(this.renderer.getRawRenderer())
     // )
-    this.renderer.getRawRenderer().setAnimationLoop(this.animate.bind(this))
+    this.renderer.getRawRenderer().setAnimationLoop(this.animate)
   }
 
   /**
@@ -1132,6 +1132,7 @@ export default class Visualizer {
           .add(xrTarget)
         this.cameraRig.position.copy(position)
         this.cameraRig.lookAt(xrTarget)
+        // Align rig's forward direction with the target (Three.js cameras look down -Z by default)
         this.cameraRig.rotateY(Math.PI)
         // Update light to follow camera in XR mode
         this.updatePointLightPosition()

--- a/src/core/visualizer.ts
+++ b/src/core/visualizer.ts
@@ -684,7 +684,10 @@ export default class Visualizer {
   }
 
   private updatePointLightPosition = () => {
-    const cameraPosition = this.camera.position
+    // In XR mode, camera.position is local (0,0,0) - use rig position instead
+    const cameraPosition = this.cameraRig
+      ? this.cameraRig.position
+      : this.camera.position
 
     // Calculate point light position based on system bounds
     if (
@@ -1121,6 +1124,8 @@ export default class Visualizer {
         this.cameraRig.position.copy(position)
         this.cameraRig.lookAt(xrTarget)
         this.cameraRig.rotateY(Math.PI)
+        // Update light to follow camera in XR mode
+        this.updatePointLightPosition()
       }
 
       // Create camera rig and position it where the camera currently is

--- a/src/core/visualizer.ts
+++ b/src/core/visualizer.ts
@@ -1226,6 +1226,9 @@ export default class Visualizer {
       const rendererSize = this.renderer.getSize()
       adjustCamera(this.camera, rendererSize.width, rendererSize.height)
       this.camera.updateProjectionMatrix()
+
+      // Update light position to follow camera (was following rig in XR mode)
+      this.updatePointLightPosition()
     })
 
     // Request hand tracking as an optional feature for gesture controls


### PR DESCRIPTION
## Overview

Adds WebXR (VR/AR) support and control/picking toggle methods to omovi.

## Changes

### New Feature: WebXR Support
- Added `enableXR()` method to Visualizer class that enables XR mode and returns a VR button
- Modified renderer to skip post-processing when in XR mode (required for stereo rendering)

### New Feature: Controls and Picking Toggle
- Added `setControlsEnabled(enabled)` method to enable/disable camera controls
- Added `setPickingEnabled(enabled)` method to enable/disable particle picking
- Added `enabled` property to InputHandler class

### Implementation Details
- When `renderer.xr.isPresenting` is true, the renderer bypasses all intermediate render targets and post-processing
- This is necessary because WebXR handles stereo rendering internally and requires direct framebuffer access
- The existing `VRButton` utility (already in the codebase) is used to create the VR entry button

## API

```typescript
// Enable WebXR and get VR button
const vrButton = visualizer.enableXR();
document.body.appendChild(vrButton);

// Disable camera controls (for embedded mode)
visualizer.setControlsEnabled(false);

// Disable particle picking
visualizer.setPickingEnabled(false);
```

## Benefits
- Simple one-method API to enable VR
- Automatic handling of render target switching during XR sessions
- Fine-grained control over user interactions for embedded scenarios
- No breaking changes to existing functionality

## Testing
- Tested with atomify using `?webxr=true` URL parameter
- VR button appears and XR session can be entered

